### PR TITLE
Bring consistency in pointer declarations

### DIFF
--- a/run.c
+++ b/run.c
@@ -52,16 +52,16 @@ typedef struct {
 
 typedef struct {
     // current wave of activations
-    float *x; // activation at current time stamp (dim,)
-    float *xb; // same, but inside a residual branch (dim,)
-    float *xb2; // an additional buffer just for convenience (dim,)
-    float *hb; // buffer for hidden dimension in the ffn (hidden_dim,)
-    float *hb2; // buffer for hidden dimension in the ffn (hidden_dim,)
-    float *q; // query (dim,)
-    float *k; // key (dim,)
-    float *v; // value (dim,)
-    float *att; // buffer for scores/attention values (seq_len,)
-    float *logits; // output logits
+    float* x; // activation at current time stamp (dim,)
+    float* xb; // same, but inside a residual branch (dim,)
+    float* xb2; // an additional buffer just for convenience (dim,)
+    float* hb; // buffer for hidden dimension in the ffn (hidden_dim,)
+    float* hb2; // buffer for hidden dimension in the ffn (hidden_dim,)
+    float* q; // query (dim,)
+    float* k; // key (dim,)
+    float* v; // value (dim,)
+    float* att; // buffer for scores/attention values (seq_len,)
+    float* logits; // output logits
     // kv cache
     float* key_cache;   // (layer, seq_len, dim)
     float* value_cache; // (layer, seq_len, dim)


### PR DESCRIPTION
Trying to enforce the same convention for the declaration of pointers. 