### PR TITLE
Docs: Compile with `-O3`

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ wget https://karpathy.ai/llama2c/model.bin -P out
 (if that doesn't work try [google drive](https://drive.google.com/file/d/1aTimLdx3JktDXxcHySNrZJOOk8Vb1qBR/view?usp=share_link)). Compile and run the C code:
 
 ```bash
-gcc -o run run.c -lm
+gcc -O3 -o run run.c -lm
 ./run out/model.bin
 ```
 


### PR DESCRIPTION
Amazing project, but it's even better than reported, if you enable `-O3`. On M2 Pro I got from 18 toks/s:

```txt
achieved tok/s: 18.328490461200566
```

to 

```txt
achieved tok/s: 96.74965746530997
```

Thanks for sharing!