### PR TITLE
sample.py works on mps (quick and dirty)

### DIFF
--- a/sample.py
+++ b/sample.py
@@ -17,7 +17,7 @@ max_new_tokens = 100 # number of tokens generated in each sample
 temperature = 1.0 # 1.0 = no change, < 1.0 = less random, > 1.0 = more random, in predictions
 top_k = 300 # retain only the top_k most likely tokens, clamp others to have 0 probability
 seed = 1337
-device = 'cuda' # examples: 'cpu', 'cuda', 'cuda:0', 'cuda:1', etc.
+device = 'mps' # examples: 'cpu', 'cuda', 'cuda:0', 'cuda:1', etc.
 #dtype = 'bfloat16' if torch.cuda.is_available() and torch.cuda.is_bf16_supported() else 'float16' # 'float32' or 'bfloat16' or 'float16'
 dtype = "float32"
 compile = False # use PyTorch 2.0 to compile the model to be faster


### PR DESCRIPTION
The torch MPS backend doesn't support complex numbers so sample.py will fail but you can rewrite to avoid using complex numbers in this PR - not meant to merge as is but have seen many people online be interested in this so figured i'd open this

didn't benchmark or ensure everything is running on mps yet

```
(llama2.c) marksaroufim@marksaroufim-mbp llama2.c % uname -m           
arm64
(llama2.c) marksaroufim@marksaroufim-mbp llama2.c % python sample.py   
Once upon a time, there was a big giraffe with a long neck. He lived in a jungle with many trees and animals to eat. One day, the giraffe saw a group of monkeys playing and having fun. He wanted to join them but he was worried he would fall and hurt himself.
But when he tried to fly, he struggled and fell over countryside. He looked and saw that the eating leaves was neat and tidy
---------------
```

EDIT: yeaaah so this makes implementation run about 10x slower from 4s on CPU to 35s on M1, so closing for now