### PR TITLE
Improved loading of config files and CLI parameters

### DIFF
--- a/configurator.py
+++ b/configurator.py
@@ -31,6 +31,9 @@ def update_config(g, verbose=True):
     # Load the variables defined in the extra config files
     for extra_config_file in args.config_files:
         extra_config = filter_dict(importlib.import_module(extra_config_file.removesuffix('.py').replace('/', '.')).__dict__)
+        # Check if the config key already exists
+        for k in extra_config.keys():
+            assert k in config_keys, f"Unknown config key {k} in file {extra_config_file}."
         if verbose:
             make_header(f'Loaded from extra config file {extra_config_file}:')
             pprint(extra_config)

--- a/sample.py
+++ b/sample.py
@@ -8,6 +8,7 @@ import torch
 import tiktoken
 from model import ModelArgs, Transformer
 from tokenizer import Tokenizer
+import configurator
 
 # -----------------------------------------------------------------------------
 out_dir = 'out' # ignored if init_from is not 'resume'
@@ -21,7 +22,7 @@ device = 'cuda' if torch.cuda.is_available() else 'cpu' # examples: 'cpu', 'cuda
 #dtype = 'bfloat16' if torch.cuda.is_available() and torch.cuda.is_bf16_supported() else 'float16' # 'float32' or 'bfloat16' or 'float16'
 dtype = "float32"
 compile = False # use PyTorch 2.0 to compile the model to be faster
-exec(open('configurator.py').read()) # overrides from command line or config file
+configurator.update_config(globals())
 # -----------------------------------------------------------------------------
 
 torch.manual_seed(seed)

--- a/train.py
+++ b/train.py
@@ -98,7 +98,7 @@ args = parser.parse_args()
 
 # Load the variables defined in the extra config files
 for extra_config_file in args.config_files:
-    extra_config = filter_dict(importlib.import_module(extra_config_file.removesuffix('.py')).__dict__)
+    extra_config = filter_dict(importlib.import_module(extra_config_file.removesuffix('.py').replace('/', '.')).__dict__)
     make_header(f'Loaded from extra config file {extra_config_file}:')
     pprint(extra_config)
     globals().update(extra_config)

--- a/train.py
+++ b/train.py
@@ -15,13 +15,15 @@ $ torchrun --nproc_per_node=8 --nnodes=2 --node_rank=0 --master_addr=123.456.123
 $ torchrun --nproc_per_node=8 --nnodes=2 --node_rank=1 --master_addr=123.456.123.456 --master_port=1234 train.py
 (If your cluster does not have Infiniband interconnect prepend NCCL_IB_DISABLE=1)
 """
-
+import argparse
+import importlib
 import math
 import os
 import time
 from contextlib import nullcontext
 from datetime import datetime
 from functools import partial
+from pprint import pprint
 
 import torch
 from model import Transformer, ModelArgs
@@ -67,14 +69,48 @@ warmup_iters = 1000  # how many steps to warm up for
 device = "cuda"  # examples: 'cpu', 'cuda', 'cuda:0', 'cuda:1' etc., or try 'mps' on macbooks
 dtype = "bfloat16"  # float32|bfloat16|float16
 compile = True  # use PyTorch 2.0 to compile the model to be faster
+
+
 # -----------------------------------------------------------------------------
-config_keys = [
-    k
-    for k, v in globals().items()
-    if not k.startswith("_") and isinstance(v, (int, float, bool, str))
-]
-exec(open("configurator.py").read())  # overrides from command line or config file
+def filter_dict(d):
+    return {
+        _k: _v
+        for _k, _v in d.items()
+        if not _k.startswith("_") and isinstance(_v, (int, float, bool, str))
+    }
+
+
+def make_header(text, n=35):
+    n = max(n, len(text))
+    print()
+    print('-' * n)
+    print(text)
+    print('-' * n)
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--config_files', nargs='*', default=[], type=str)
+config_keys = filter_dict(globals())
+for k, default in config_keys.items():
+    _type = type(default)
+    parser.add_argument(f'--{k}', metavar="", type=_type, help=f"{_type.__name__} (default: {default})")
+args = parser.parse_args()
+
+# Load the variables defined in the extra config files
+for extra_config_file in args.config_files:
+    extra_config = filter_dict(importlib.import_module(extra_config_file.removesuffix('.py')).__dict__)
+    make_header(f'Loaded from extra config file {extra_config_file}:')
+    pprint(extra_config)
+    globals().update(extra_config)
+
+# Update variables that have been set via CLI
+cli_params = {k: v for k, v in args.__dict__.items() if v is not None}
+make_header('Loaded from CLI params:')
+pprint(cli_params)
+globals().update(cli_params)
 config = {k: globals()[k] for k in config_keys}  # will be useful for logging
+make_header('Full config:')
+pprint(config)
 # -----------------------------------------------------------------------------
 
 # fixing some hyperparams to sensible defaults


### PR DESCRIPTION
Hi Andrej,

Thank you for this project. According to `configurator.py`, you are looking for a better, simpler Python solution to  parameter loading. 
This PR introduces `argparse` for parameter loading, while still adhering to the constraints of the original code (overwriting globals, not having to write config.[param], optional loading from param files).
By using `argparse`, it is very easy to get an overview over all the tunable variables, their types and their defaults:
```
$ python3 train.py -h
usage: train.py [-h] [--config_files [CONFIG_FILES ...]] [--out_dir] [--eval_interval] [--log_interval] [--eval_iters] [--eval_only]
                [--always_save_checkpoint] [--init_from] [--wandb_log] [--wandb_project] [--wandb_run_name] [--batch_size] [--max_seq_len] [--dim]
                [--n_layers] [--n_heads] [--multiple_of] [--dropout] [--gradient_accumulation_steps] [--learning_rate] [--max_iters] [--weight_decay]
                [--beta1] [--beta2] [--grad_clip] [--decay_lr] [--warmup_iters] [--device] [--dtype] [--compile]

options:
  -h, --help            show this help message and exit
  --config_files [CONFIG_FILES ...]
  --out_dir             str (default: out)
  --eval_interval       int (default: 2000)
  --log_interval        int (default: 1)
  --eval_iters          int (default: 100)
[... snip ...]
``` 


Basic usage example:
```sh
$ cat config/test_config1.py 
beta1 = 0.12345
```
```sh
$ cat config/test_config2.py 
beta1 = 0.98765
```
```
$ python3 train.py --config_files config/test_config1.py config/test_config2.py              

-----------------------------------------------------
Loaded from extra config file config/test_config1.py:
-----------------------------------------------------
{'beta1': 0.12345}

-----------------------------------------------------
Loaded from extra config file config/test_config2.py:
-----------------------------------------------------
{'beta1': 0.98765}

-----------------------------------
Loaded from CLI params:
-----------------------------------
{'config_files': ['config/test_config1.py', 'config/test_config2.py']}

-----------------------------------
Full config:
-----------------------------------
{'always_save_checkpoint': False,
 'batch_size': 128,
 'beta1': 0.98765,
 'beta2': 0.95,
 'compile': True,
 'decay_lr': True,
 'device': 'cuda',
 'dim': 288,
 'dropout': 0.0,
 'dtype': 'bfloat16',
 'eval_interval': 2000,
 'eval_iters': 100,
 'eval_only': False,
 'grad_clip': 1.0,
 'gradient_accumulation_steps': 4,
 'init_from': 'scratch',
 'learning_rate': 0.0005,
 'log_interval': 1,
 'max_iters': 100000,
 'max_seq_len': 256,
 'multiple_of': 32,
 'n_heads': 6,
 'n_layers': 6,
 'out_dir': 'out',
 'wandb_log': False,
 'wandb_project': 'llamac',
 'wandb_run_name': 'run2023_07_24_01_24_26',
 'warmup_iters': 1000,
 'weight_decay': 0.1}
[... snip ...]
```

Optional override from CLI:
```
$ python3 train.py --config_files config/test_config1.py config/test_config2.py --beta1=0.999

-----------------------------------------------------
Loaded from extra config file config/test_config1.py:
-----------------------------------------------------
{'beta1': 0.12345}

-----------------------------------------------------
Loaded from extra config file config/test_config2.py:
-----------------------------------------------------
{'beta1': 0.98765}

-----------------------------------
Loaded from CLI params:
-----------------------------------
{'beta1': 0.999,
 'config_files': ['config/test_config1.py', 'config/test_config2.py']}

-----------------------------------
Full config:
-----------------------------------
{'always_save_checkpoint': False,
 'batch_size': 128,
 'beta1': 0.999,  # <-------- beta1 is set from CLI
 'beta2': 0.95,
 'compile': True,
 'decay_lr': True,
 'device': 'cuda',
 'dim': 288,
 'dropout': 0.0,
 'dtype': 'bfloat16',
 'eval_interval': 2000,
 'eval_iters': 100,
 'eval_only': False,
 'grad_clip': 1.0,
 'gradient_accumulation_steps': 4,
 'init_from': 'scratch',
 'learning_rate': 0.0005,
 'log_interval': 1,
 'max_iters': 100000,
 'max_seq_len': 256,
 'multiple_of': 32,
 'n_heads': 6,
 'n_layers': 6,
 'out_dir': 'out',
 'wandb_log': False,
 'wandb_project': 'llamac',
 'wandb_run_name': 'run2023_07_24_01_25_25',
 'warmup_iters': 1000,
 'weight_decay': 0.1}
[... snip ...]
```

Warning: Code is only superficially tested right now, there might be some unintended side effects.