### PR TITLE
Simplify Softmax

### DIFF
--- a/run.c
+++ b/run.c
@@ -207,15 +207,14 @@ void softmax(float* x, int size) {
             max_val = x[i];
         }
     }
-    // e^x
-    for (int i = 0; i < size; i++) {
-        x[i] = exp(x[i] - max_val);
-    }
+
     // normalize
     float sum = 0.0f;
     for (int i = 0; i < size; i++) {
+        x[i] = exp(x[i] - max_val);
         sum += x[i];
     }
+
     for (int i = 0; i < size; i++) {
         x[i] /= sum;
     }


### PR DESCRIPTION
Explicitly fuse two loops in softmax. It seems `-O3` doesn't catch this and fusing them results in a ~12.5% speedup on my linux machine and an ~18.5% speedup on my macbook air m2 for a 32k vocab table (for softmax only --- I don't have benchmarks for the end-to-end usage).