### PR TITLE
Use embedded xoroshiro128+ prng instead of stdlib rand()

### DIFF
--- a/run.c
+++ b/run.c
@@ -169,24 +169,24 @@ void checkpoint_init_weights(TransformerWeights *w, Config* p, FILE* f) {
 // pseudo-random number generation
 
 static inline unsigned int xoro_rotl(const unsigned int x, int k) {
-	return (x << k) | (x >> (32 - k));
+    return (x << k) | (x >> (32 - k));
 }
 
 static unsigned int _rng_state[4] = {9874, 6993, 3478, 4392};
 
 // xoroshiro128+ PRNG https://prng.di.unimi.it/
 unsigned int xoro_rand(void) {
-	const unsigned int result = _rng_state[0] + _rng_state[3];
-	const unsigned int t = _rng_state[1] << 9;
+    const unsigned int result = _rng_state[0] + _rng_state[3];
+    const unsigned int t = _rng_state[1] << 9;
 
-	_rng_state[2] ^= _rng_state[0];
-	_rng_state[3] ^= _rng_state[1];
-	_rng_state[1] ^= _rng_state[2];
-	_rng_state[0] ^= _rng_state[3];
-	_rng_state[2] ^= t;
-	_rng_state[3] = xoro_rotl(_rng_state[3], 11);
+    _rng_state[2] ^= _rng_state[0];
+    _rng_state[3] ^= _rng_state[1];
+    _rng_state[1] ^= _rng_state[2];
+    _rng_state[0] ^= _rng_state[3];
+    _rng_state[2] ^= t;
+    _rng_state[3] = xoro_rotl(_rng_state[3], 11);
 
-	return result;
+    return result;
 }
 
 // xoroshiro128+ PRNG https://prng.di.unimi.it/

--- a/run.c
+++ b/run.c
@@ -172,7 +172,7 @@ static inline unsigned int xoro_rotl(const unsigned int x, int k) {
 	return (x << k) | (x >> (32 - k));
 }
 
-static unsigned int _rng_state[4];
+static unsigned int _rng_state[4] = {9874, 6993, 3478, 4392};
 
 // xoroshiro128+ PRNG https://prng.di.unimi.it/
 unsigned int xoro_rand(void) {

--- a/run.c
+++ b/run.c
@@ -191,7 +191,7 @@ unsigned int xoro_rand(void) {
 
 // xoroshiro128+ PRNG https://prng.di.unimi.it/
 float xoro_rand_float(void) {
-    return (float)(xoro_rand() & 0x7FFFFF) / (float)0x7FFFFF;
+    return (float)(xoro_rand() >> 9) / (float)0x7FFFFF;
 }
 
 void xoro_seed(int seed) {

--- a/run.c
+++ b/run.c
@@ -195,10 +195,11 @@ float xoro_rand_float(void) {
 }
 
 void xoro_seed(int seed) {
+    seed = seed <= 0 ? -seed + 1 : seed;
     _rng_state[0] = (unsigned int)seed;
     _rng_state[1] = ~(unsigned int)seed;
-    _rng_state[2] = (unsigned int)(seed << 16);
-    _rng_state[3] = (unsigned int)(seed >> 16);
+    _rng_state[2] = xoro_rotl((unsigned int)seed, 16);
+    _rng_state[3] = ~xoro_rotl((unsigned int)seed, 16);
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
The C standard library `rand()` implementation is neither portable nor a particularly good prng. This PR replaces it with a small embedded xoroshiro128+ prng from https://prng.di.unimi.it/ which is public domain, well tested, and is the standard prng in many places (iirc Zig and Rust have it as their default prng).