### PR TITLE
Register `freqs_cis` as non-persistent buffer

### DIFF
--- a/model.py
+++ b/model.py
@@ -195,7 +195,8 @@ class Transformer(nn.Module):
         self.tok_embeddings.weight = self.output.weight # https://paperswithcode.com/method/weight-tying
 
         # some useful precompute for the RoPE relative positional embeddings. TODO why * 2 here? confuse
-        self.freqs_cis = precompute_freqs_cis(self.params.dim // self.params.n_heads, self.params.max_seq_len * 2)
+        freqs_cis = precompute_freqs_cis(self.params.dim // self.params.n_heads, self.params.max_seq_len * 2)
+        self.register_buffer("freqs_cis", freqs_cis, persistent=False)
         
         # init all weights
         self.apply(self._init_weights)
@@ -215,7 +216,6 @@ class Transformer(nn.Module):
     def forward(self, tokens, targets=None):
         _bsz, seqlen = tokens.shape
         h = self.tok_embeddings(tokens)
-        self.freqs_cis = self.freqs_cis.to(h.device)
         freqs_cis = self.freqs_cis[:seqlen]
 
         for layer in self.layers:


### PR DESCRIPTION
This PR changes `self.freqs_cis` from being a plain attribute to a registered buffer, meaning that it moves to CUDA with `model.to(device)` (as opposed to lazily moving on the first forward). The `persistent=False` means it does not appear in `state_dict()`, matching existing behavior.

This change itself does not affect the functionality. However, I was experimenting with CUDA graph trees, which require all tensors to be on the same device in the compiled function, otherwise raising an error like:
```
skipping cudagraphs due to multiple devices
```
(CUDA graph trees are a new feature invoked via `torch.compile(model, options={"triton.cudagraphs": True, "triton.cudagraph_trees": True})`, and CUDA graphs generally help with CPU-bound workloads, like the current training settings in the repo (due to small model size and batch size).)

