### PR TITLE
Add multi OS binary portability support via Cosmopolitan libc toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,37 @@
+## Llama 2 everywhere
+
+Standalone and 64bit Binary Portable Llama 2 Inference in one file of C
+
+A friendly fork of the excellent https://github.com/karpathy/llama2.c
+
+Our goal is to mirror the progress of https://github.com/karpathy/llama2.c, add improvements such as as OpenCL / Vulkan GPU inference, webserver etc which certainly would not fit in the upstream do to the minimal / simplicity / elegance requirements constraints there.
+
+# Features
+
++ Executable that runs on
+  + GNU/Systemd
+  + BSD
+  ++ FreeBSD
+  ++ OpenBSD
+  ++ NetBSD
+  + XNU's Not UNIX
+  + Bare Metal (Not fully functional yet but almost...)
+  + Windows
+
++ Runs on ARM64 (aarch64), x86_64
+
++ Standalone
+  + Embedded model
+
+These features depend on a specific cosmocc toolchain: https://github.com/jart/cosmopolitan
+
+Building this with gcc or clang would result in normal binaries similar to upstream.
+
+Read more:
+[How to build](https://github.com/trholding/llama2.c/edit/master/README.md#binary-portability-even-more-magic)
+
+Download the prebuilt run.com binary from releases
+
 ## llama2.c
 
 <img src="assets/llama_cute.jpg" width="300" height="300">

--- a/README.md
+++ b/README.md
@@ -120,6 +120,72 @@ gcc -Ofast -o run run.c -lm
 
 Also, I saw someone report higher throughput replacing `gcc` with `clang`.
 
+## binary portability (even more magic)
+
+Have you ever wanted to inference a baby Llama 2 model with a single executable on any OS or *as OS? No? Well, now you can!
+
+By making use of the Cosmopolitan libc toolchain to build llama2.c we get the following features:
+
++ Executable that runs on
+  + GNU/Systemd
+  + FreeBSD
+  + OpenBSD
+  + NetBSD
+  + XNU's Not UNIX
+  + Bare Metal (-D COSMO_METAL) (*Not fully functional yet)
+  + Windows
+
++ Runs on 
+  + ARM64 via Blink x86-64 emulation (-D COSMO_BLINK) (Slow)
+  + x86_64
+
++ Standalone
+  + Embedded model in executable (-D COSMO_ZIP)
+
+Instructions
+
+Get and build the comopolitan libc toolchain:
+
+Follow instructions at https://github.com/jart/cosmopolitan
+
+Or do:
+
+```
+sudo mkdir -p /opt
+sudo chmod 1777 /opt
+git clone https://github.com/jart/cosmopolitan /opt/cosmo
+cd /opt/cosmo
+make -j8 toolchain
+mkdir -p /opt/cosmos/bin
+export PATH="/opt/cosmos/bin:$PATH"
+echo 'PATH="/opt/cosmos/bin:$PATH"' >>~/.profile
+sudo ln -sf /opt/cosmo/tool/scripts/cosmocc /opt/cosmos/bin/cosmocc
+sudo ln -sf /opt/cosmo/tool/scripts/cosmoc++ /opt/cosmos/bin/cosmoc++
+```
+
+Example build to generate a Actually Portable Executable (APE):
+
+```
+$ cosmocc -O3 -Ofast -funsafe-math-optimizations -ffast-math -D COSMO_BLINK \
+-D COSMO_METAL -D COSMO_ZIP -o run.com run.c -lm
+
+Add model.bin and tokenizer.bin to executable:
+$ zip run.com out/model.bin
+$ zip run.com tokenizer.bin
+```
+
+Run or copy to any supported system and run:
+
+```
+If model is embedded:
+
+$ ./run.com
+
+Else
+
+$ ./run.com model.bin
+```
+
 ## unsorted todos
 
 - why is there a leading space in C sampling code when we `./run`?

--- a/run.c
+++ b/run.c
@@ -415,9 +415,9 @@ int main(int argc, char *argv[]) {
     if (argc < 2) {
         printf("Usage: %s <checkpoint_file> [temperature] [seed]\n", argv[0]);
         return 1;
-    }
-    #endif
+    }    
     checkpoint = argv[1];
+    #endif
     // temperature is optional
     if (argc >= 3) {
         temperature = atof(argv[2]);


### PR DESCRIPTION
It is possible to compile once and run the binary on multiple OS via Cosmopolitan libc toolchain. I have added the necessary pre processor directives to enable that. Please have a look.

These are the features that come nearly free:

+ Executable that runs on
  + GNU/Systemd
  + FreeBSD
  + OpenBSD
  + NetBSD
  + XNU's Not UNIX
  + Bare Metal (-D COSMO_METAL) [Not fully functional]
  + Windows

+ Runs on 
  + ARM64 via Blink x86-64 emulation (-D COSMO_BLINK)
  + x86_64

+ Standalone
  + Embedded model in executable (-D COSMO_ZIP)

Instructions

Get and build the comopolitan libc toolchain:

Follow instructions at https://github.com/jart/cosmopolitan

Or do:

```
sudo mkdir -p /opt
sudo chmod 1777 /opt
git clone https://github.com/jart/cosmopolitan /opt/cosmo
cd /opt/cosmo
make -j8 toolchain
mkdir -p /opt/cosmos/bin
export PATH="/opt/cosmos/bin:$PATH"
echo 'PATH="/opt/cosmos/bin:$PATH"' >>~/.profile
sudo ln -sf /opt/cosmo/tool/scripts/cosmocc /opt/cosmos/bin/cosmocc
sudo ln -sf /opt/cosmo/tool/scripts/cosmoc++ /opt/cosmos/bin/cosmoc++
```

Example build to generate a Actually Portable Executable (APE):

```
$ cosmocc -O3 -Ofast -funsafe-math-optimizations -ffast-math -D COSMO_BLINK \
-D COSMO_METAL -D COSMO_ZIP -o run.com run.c -lm

Add model.bin and tokenizer.bin to executable:
$ zip run.com out/model.bin
$ zip run.com tokenizer.bin
```

Run or copy to any supported system and run:

```
If model is embedded:

$ ./run.com

Else

$ ./run.com model.bin

```