### PR TITLE
Have DDP ignore `freqs_cis` to avoid broadcast

### DIFF
--- a/train.py
+++ b/train.py
@@ -191,6 +191,10 @@ if compile:
 
 # wrap model into DDP container
 if ddp:
+    # Ignore the `freqs_cis` buffer so that DDP does not broadcast it at
+    # construction time since NCCL does not support `ComplexFloat`
+    prefix = "_orig_mod." if compile else ""
+    model._ddp_params_and_buffers_to_ignore = {prefix + "freqs_cis"}
     model = DDP(model, device_ids=[ddp_local_rank])
 
 # helps estimate an arbitrarily accurate loss over either split using many batches


### PR DESCRIPTION
Sorry for not running DDP to catch this before merging. This PR fixes the error:
```
RuntimeError: Input tensor data type is not supported for NCCL process group: ComplexFloat
```
This solution is not very elegant, but as long as we ensure that `freqs_cis` is replicated across data parallel workers, then this is safe (which is the case since it is computed statically once and never changed thereafter). We use this private `_ddp_params_and_buffers_to_ignore` attribute to notify DDP to skip `freqs_cis` when broadcasting module states from rank 0.

I tested via:
```
torchrun --standalone --nproc_per_node=2 train.py
```
with both `compile = True` and `compile = False`.