### PR TITLE
Fuse q, k, v matmuls

### DIFF
--- a/run.c
+++ b/run.c
@@ -225,42 +225,19 @@ void matmul(float* xout, float* x, float* w, int n, int d) {
 void qkv_matmuls(float* q, float* k, float* v, float* xb, float* wq, float* wk, float* wv, int l, int dim) {
     #pragma omp parallel for
     for (int i = 0; i < dim; i += 4) {
-        float q_val[4] = {0.0f};
-        float k_val[4] = {0.0f};
-        float v_val[4] = {0.0f};
-
         for (int j = 0; j < dim; j += 4) {
-            // Load weights
             float* wq_ptr = wq + (l * dim + i) * dim + j;
             float* wk_ptr = wk + (l * dim + i) * dim + j;
             float* wv_ptr = wv + (l * dim + i) * dim + j;
-
-            // Load input
             float* xb_ptr = xb + j;
 
-            // Perform matmul
+            // Perform matmul with loop unrolling
             for (int k_idx = 0; k_idx < 4; k_idx++) {
-                q_val[k_idx] += wq_ptr[k_idx] * xb_ptr[k_idx];
-                k_val[k_idx] += wk_ptr[k_idx] * xb_ptr[k_idx];
-                v_val[k_idx] += wv_ptr[k_idx] * xb_ptr[k_idx];
+                q[i + k_idx] += wq_ptr[k_idx] * xb_ptr[k_idx];
+                k[i + k_idx] += wk_ptr[k_idx] * xb_ptr[k_idx];
+                v[i + k_idx] += wv_ptr[k_idx] * xb_ptr[k_idx];
             }
         }
-
-        // Store results
-        q[i] = q_val[0];
-        q[i + 1] = q_val[1];
-        q[i + 2] = q_val[2];
-        q[i + 3] = q_val[3];
-
-        k[i] = k_val[0];
-        k[i + 1] = k_val[1];
-        k[i + 2] = k_val[2];
-        k[i + 3] = k_val[3];
-
-        v[i] = v_val[0];
-        v[i + 1] = v_val[1];
-        v[i + 2] = v_val[2];
-        v[i + 3] = v_val[3];
     }
 }
 

--- a/run.c
+++ b/run.c
@@ -222,6 +222,48 @@ void matmul(float* xout, float* x, float* w, int n, int d) {
     }
 }
 
+void qkv_matmuls(float* q, float* k, float* v, float* xb, float* wq, float* wk, float* wv, int l, int dim) {
+    #pragma omp parallel for
+    for (int i = 0; i < dim; i += 4) {
+        float q_val[4] = {0.0f};
+        float k_val[4] = {0.0f};
+        float v_val[4] = {0.0f};
+
+        for (int j = 0; j < dim; j += 4) {
+            // Load weights
+            float* wq_ptr = wq + (l * dim + i) * dim + j;
+            float* wk_ptr = wk + (l * dim + i) * dim + j;
+            float* wv_ptr = wv + (l * dim + i) * dim + j;
+
+            // Load input
+            float* xb_ptr = xb + j;
+
+            // Perform matmul
+            for (int k_idx = 0; k_idx < 4; k_idx++) {
+                q_val[k_idx] += wq_ptr[k_idx] * xb_ptr[k_idx];
+                k_val[k_idx] += wk_ptr[k_idx] * xb_ptr[k_idx];
+                v_val[k_idx] += wv_ptr[k_idx] * xb_ptr[k_idx];
+            }
+        }
+
+        // Store results
+        q[i] = q_val[0];
+        q[i + 1] = q_val[1];
+        q[i + 2] = q_val[2];
+        q[i + 3] = q_val[3];
+
+        k[i] = k_val[0];
+        k[i + 1] = k_val[1];
+        k[i + 2] = k_val[2];
+        k[i + 3] = k_val[3];
+
+        v[i] = v_val[0];
+        v[i + 1] = v_val[1];
+        v[i + 2] = v_val[2];
+        v[i + 3] = v_val[3];
+    }
+}
+
 void transformer(int token, int pos, Config* p, RunState* s, TransformerWeights* w) {
     
     // a few convenience variables
@@ -245,9 +287,7 @@ void transformer(int token, int pos, Config* p, RunState* s, TransformerWeights*
         rmsnorm(s->xb, x, w->rms_att_weight + l*dim, dim);
 
         // qkv matmuls for this position
-        matmul(s->q, s->xb, w->wq + l*dim*dim, dim, dim);
-        matmul(s->k, s->xb, w->wk + l*dim*dim, dim, dim);
-        matmul(s->v, s->xb, w->wv + l*dim*dim, dim, dim);
+        qkv_matmuls(s->q, s->k, s->v, s->xb, w->wq, w->wk, w->wv, l, dim);
 
         // apply RoPE rotation to the q and k vectors for each head
         for (int h = 0; h < p->n_heads; h++) {


### PR DESCRIPTION
PR fuses qkv matmuls.

Below are benchmarks per make recipe using [hyperfine](https://github.com/sharkdp/hyperfine) benchmarking tool, comparing the performance between the original `run` (no fuse) and `run_qkv` (fused qkv matmuls)

# run

```
maknee@maknee-gpu:~/llama2.c$ hyperfine --warmup 5 --runs 10 "./run model.bin 0.0" "./run_qkv model.bin 0.0"
Benchmark 1: ./run model.bin 0.0
  Time (mean ± σ):      2.028 s ±  0.001 s    [User: 2.012 s, System: 0.016 s]
  Range (min … max):    2.026 s …  2.031 s    10 runs
 
Benchmark 2: ./run_qkv model.bin 0.0
  Time (mean ± σ):      1.873 s ±  0.023 s    [User: 1.856 s, System: 0.017 s]
  Range (min … max):    1.858 s …  1.925 s    10 runs
 
Summary
  ./run_qkv model.bin 0.0 ran
    1.08 ± 0.01 times faster than ./run model.bin 0.0
```

---

```
maknee@maknee-gpu:~/llama2.c$ hyperfine --warmup 5 --runs 10 "./run model44m.bin 0.0" "./run_qkv model44m.bin 0.0"
Benchmark 1: ./run model44m.bin 0.0
  Time (mean ± σ):      6.238 s ±  0.130 s    [User: 6.194 s, System: 0.044 s]
  Range (min … max):    6.136 s …  6.402 s    10 runs
 
Benchmark 2: ./run_qkv model44m.bin 0.0
  Time (mean ± σ):      5.514 s ±  0.102 s    [User: 5.469 s, System: 0.045 s]
  Range (min … max):    5.416 s …  5.631 s    10 runs
 
Summary
  ./run_qkv model44m.bin 0.0 ran
    1.13 ± 0.03 times faster than ./run model44m.bin 0.0
```

# runfast

```
maknee@maknee-gpu:~/llama2.c$ hyperfine --warmup 5 --runs 10 "./run model.bin 0.0" "./run_qkv model.bin 0.0"
Benchmark 1: ./run model.bin 0.0
  Time (mean ± σ):     495.9 ms ±   3.9 ms    [User: 479.5 ms, System: 16.4 ms]
  Range (min … max):   490.6 ms … 500.8 ms    10 runs
 
Benchmark 2: ./run_qkv model.bin 0.0
  Time (mean ± σ):     465.9 ms ±   6.4 ms    [User: 450.6 ms, System: 15.2 ms]
  Range (min … max):   454.5 ms … 473.0 ms    10 runs

Summary
  ./run_qkv model.bin 0.0 ran
    1.06 ± 0.02 times faster than ./run model.bin 0.0
```

---

```
maknee@maknee-gpu:~/llama2.c$ hyperfine --warmup 5 --runs 10 "./run model44m.bin 0.0" "./run_qkv model44m.bin 0.0"
Benchmark 1: ./run model44m.bin 0.0
  Time (mean ± σ):      1.733 s ±  0.002 s    [User: 1.685 s, System: 0.048 s]
  Range (min … max):    1.730 s …  1.737 s    10 runs
 
Benchmark 2: ./run_qkv model44m.bin 0.0
  Time (mean ± σ):      1.647 s ±  0.002 s    [User: 1.597 s, System: 0.050 s]
  Range (min … max):    1.645 s …  1.651 s    10 runs
 
Summary
  ./run_qkv model44m.bin 0.0 ran
    1.05 ± 0.00 times faster than ./run model44m.bin 0.0
```

# runomp

```
maknee@maknee-gpu:~/llama2.c$ hyperfine --warmup 10 --runs 100 "OMP_NUM_THREADS=8 ./run model.bin 0.0" "OMP_NUM_THREADS=8 ./run_qkv model.bin 0.0"
Benchmark 1: OMP_NUM_THREADS=8 ./run model.bin 0.0
  Time (mean ± σ):      59.3 ms ±   3.8 ms    [User: 368.2 ms, System: 15.7 ms]
  Range (min … max):    57.4 ms …  89.3 ms    100 runs
 
Benchmark 2: OMP_NUM_THREADS=8 ./run_qkv model.bin 0.0
  Time (mean ± σ):      55.5 ms ±   2.2 ms    [User: 338.8 ms, System: 14.8 ms]
  Range (min … max):    53.5 ms …  74.6 ms    100 runs
 
Summary
  OMP_NUM_THREADS=8 ./run_qkv model.bin 0.0 ran
    1.07 ± 0.08 times faster than OMP_NUM_THREADS=8 ./run model.bin 0.0
```

---

```
maknee@maknee-gpu:~/llama2.c$ hyperfine --warmup 10 --runs 100 "OMP_NUM_THREADS=8 ./run model44m.bin 0.0" "OMP_NUM_THREADS=8 ./run_qkv model44m.bin 0.0"
Benchmark 1: OMP_NUM_THREADS=8 ./run model44m.bin 0.0
  Time (mean ± σ):      59.3 ms ±   2.2 ms    [User: 368.1 ms, System: 15.7 ms]
  Range (min … max):    57.7 ms …  79.9 ms    100 runs

Benchmark 2: OMP_NUM_THREADS=8 ./run_qkv model44m.bin 0.0
  Time (mean ± σ):      56.1 ms ±   3.2 ms    [User: 342.4 ms, System: 15.5 ms]
  Range (min … max):    54.5 ms …  79.7 ms    100 runs

Summary
  OMP_NUM_THREADS=8 ./run_qkv model.bin 0.0 ran
    1.06 ± 0.07 times faster than OMP_NUM_THREADS=8 ./run model.bin 0.0
```

Here are the specs of the machine/env I'm running on

```
AMD Ryzen 7 7800X3D 8-Core Processor
128GB DDR5 5200 ram
```
```
Linux maknee-gpu 5.19.0-46-generic #47~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Wed Jun 21 15:35:31 UTC 2 x86_64 x86_64 x86_64 GNU/Linux
gcc version 11.3.0 (Ubuntu 11.3.0-1ubuntu1~22.04.1) 
```
