### PR TITLE
Handle failed time_in_ms

### DIFF
--- a/run.c
+++ b/run.c
@@ -449,7 +449,7 @@ int main(int argc, char *argv[]) {
     // create and init the application RunState
     RunState state;
     malloc_run_state(&state, &config);
-    
+
     // the current position we are in
     long start = time_in_ms();
     int next;
@@ -483,7 +483,8 @@ int main(int argc, char *argv[]) {
 
     // report achieved tok/s
     long end = time_in_ms();
-    printf("\nachieved tok/s: %f\n", steps / (double)(end-start)*1000);
+    if (start != -1 && end != -1)
+        printf("\nachieved tok/s: %f\n", steps / (double)(end - start) * 1000);
 
     // memory and file handles cleanup
     free_run_state(&state);


### PR DESCRIPTION
`time_in_ms()` returns -1 if there's an error, but this is never checked for which can lead to an inaccurate tok/s print message.