### PR TITLE
Windows compat: Use GetTickCount for delta timer

### DIFF
--- a/run.c
+++ b/run.c
@@ -360,6 +360,7 @@ int argmax(float* v, int n) {
 // ----------------------------------------------------------------------------
 
 long time_in_ms() {
+#ifndef _WIN32
     struct timespec time;
     // Get the current time with nanosecond precision
     if (clock_gettime(CLOCK_REALTIME, &time) == 0) {
@@ -368,6 +369,9 @@ long time_in_ms() {
         perror("clock_gettime");
         return -1; // Return -1 to indicate an error
     }
+#else
+    return GetTickCount();
+#endif
 }
 
 int main(int argc, char *argv[]) {


### PR DESCRIPTION
Intentionally not including a windows header here to avoid merge conflict on include with mmap support. cl.exe doesn't complain, mingw warns.