### PR TITLE
readme: Include reference to go port

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ If your candidate PRs have elements of these it doesn't mean they won't get merg
 ## notable forks
 
 - [llama2.rs](https://github.com/gaxler/llama2.rs) by @gaxler: a Rust port of this project
+- [go-llama2](https://github.com/tmc/go-llama2) by @tmc: a Go port of this project
 
 ## License
 


### PR DESCRIPTION
This adds a link to my go port of this project. I'd love to get more interest around how to maintain and enhance this go language port of this code.