### PR TITLE
Added Go ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ If your candidate PRs have elements of these it doesn't mean they won't get merg
 
 - [llama2.rs](https://github.com/gaxler/llama2.rs) by @gaxler: a Rust port of this project
 - [go-llama2](https://github.com/tmc/go-llama2) by @tmc: a Go port of this project
+- [llama2.go](https://github.com/nikolaydubina/llama2.go) by @nikolaydubina: a Go port of this project
 
 ## unsorted todos
 

--- a/README.md
+++ b/README.md
@@ -190,6 +190,8 @@ If your candidate PRs have elements of these it doesn't mean they won't get merg
 - [llama2.rs](https://github.com/gaxler/llama2.rs) by @gaxler: a Rust port of this project
 - [go-llama2](https://github.com/tmc/go-llama2) by @tmc: a Go port of this project
 - [llama2.go](https://github.com/nikolaydubina/llama2.go) by @nikolaydubina: a Go port of this project
+- [llama2.go](https://github.com/haormj/llama2.go) by @haormj: a Go port of this project
+- [llama2.go](https://github.com/saracen/llama2.go) by @saracen: a Go port of this project
 
 ## unsorted todos
 


### PR DESCRIPTION
Hello,

I have made few days ago Go port of this model. It is different from other Go port. It follows typical Go standard and notations better while preserving style of llama2.c

> I also think I did Go port first. haha !
> UPD: I see other versions of it popup: https://github.com/haormj/llama2.go so it is debatable who is first, if that matters anyways.

Anyways,

Would be great to include it here!

Thank you!