### PR TITLE
Add Makefile target to support builds on amazon linux & centos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,15 @@ runomp: run.c
 win64: 
 	x86_64-w64-mingw32-gcc-win32 -Ofast -D_WIN32 -o run.exe -I. run.c win.c
 
+# compiles with gnu99 standard flags for amazon linux, coreos, etc. compatibility
+.PHONY: rungnu
+rungnu:
+	$(CC) -Ofast -std=gnu11 -o run run.c -lm
+
+.PHONY: runompgnu
+rungnu:
+	$(CC) -Ofast -fopenmp -std=gnu11 run.c  -lm  -o run
+
 .PHONY: clean
 clean:
 	rm -f run

--- a/README.md
+++ b/README.md
@@ -159,6 +159,8 @@ Depending on your system resources you may want to tweak these hyperparameters. 
 
 On **Windows**, use `build_msvc.bat` in a Visual Studio Command Prompt to build with msvc, or you can use `make win64` to use mingw compiler toolchain from linux or windows to build the windows target. MSVC build will automatically use openmp and max threads appropriate for your CPU unless you set `OMP_NUM_THREADS` env.
 
+On **Centos 7**, **Amazon Linux 2018** use `rungnu` Makefile target: `make rungnu` or `make runompgnu` to use openmp.
+
 ## ack
 
 I trained the llama2.c storyteller models on a 4X A100 40GB box graciously provided by the excellent [Lambda labs](https://lambdalabs.com/service/gpu-cloud), thank you.


### PR DESCRIPTION
Added `rungnu` Makefile target to compile on amazon linux, centos OSs
It fixes issues #100 #136 