### PR TITLE
Remove second ifdef by porting clock_gettime to win.c

### DIFF
--- a/run.c
+++ b/run.c
@@ -365,15 +365,9 @@ int argmax(float* v, int n) {
 // ----------------------------------------------------------------------------
 
 long time_in_ms() {
-#if defined _WIN32
-    // windows specific way to get time
-    return GetTickCount();
-#else
-    // linux specific way to get time
     struct timespec time;
     clock_gettime(CLOCK_REALTIME, &time);
     return time.tv_sec * 1000 + time.tv_nsec / 1000000;
-#endif
 }
 
 int main(int argc, char *argv[]) {

--- a/win.c
+++ b/win.c
@@ -176,3 +176,11 @@ int munlock(const void *addr, size_t len)
     
     return -1;
 }
+
+// Portable clock_gettime function for Windows
+int clock_gettime(int clk_id, struct timespec *tp) {
+    DWORD ticks = GetTickCount();
+    tp->tv_sec = ticks / 1000;
+    tp->tv_nsec = (ticks % 1000) * 1000000;
+    return 0;
+}

--- a/win.h
+++ b/win.h
@@ -3,6 +3,7 @@
 
 #define WIN32_LEAN_AND_MEAN      // Exclude rarely-used stuff from Windows headers
 #include <windows.h>
+#include <time.h>
 
 
 // Below code is originally from mman-win32
@@ -47,12 +48,16 @@ extern "C" {
 #define MS_SYNC         2
 #define MS_INVALIDATE   4
 
+/* Flags for portable clock_gettime call. */
+#define CLOCK_REALTIME  0
+
 void*   mmap(void *addr, size_t len, int prot, int flags, int fildes, off_t off);
 int     munmap(void *addr, size_t len);
 int     mprotect(void *addr, size_t len, int prot);
 int     msync(void *addr, size_t len, int flags);
 int     mlock(const void *addr, size_t len);
 int     munlock(const void *addr, size_t len);
+int     clock_gettime(int clk_id, struct timespec *tp);
 
 #ifdef __cplusplus
 };

--- a/win.h
+++ b/win.h
@@ -13,9 +13,9 @@
  * mman-win32
  */
 
-#ifndef _WIN32_WINNT		// Allow use of features specific to Windows XP or later.                   
-#define _WIN32_WINNT 0x0501	// Change this to the appropriate value to target other versions of Windows.
-#endif						
+#ifndef _WIN32_WINNT            // Allow use of features specific to Windows XP or later.
+#define _WIN32_WINNT    0x0501  // Change this to the appropriate value to target other versions of Windows.
+#endif
 
 /* All the headers include this file. */
 #ifndef _MSC_VER


### PR DESCRIPTION
As there were discussions yesterday regarding further simplification of `run.c` I've created a PR with similar approach as in my PR #96 to remove `#if defined _WIN32` in `time_in_ms`.
The solution is to move WIN32 specific code to `win.c, win.h` in order to keep `run.c` clean.

Ported & functionally compatible version of `clock_gettime` moved to `win.c` 
```C
int clock_gettime(int clk_id, struct timespec *tp) {
    DWORD ticks = GetTickCount();
    tp->tv_sec = ticks / 1000;
    tp->tv_nsec = (ticks % 1000) * 1000000;
    return 0;
}
```

CI: https://github.com/tairov/llama2.c/actions/runs/5681971036