### PR TITLE
fix: Use correct compiler for Win64 GCC in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ runomp: run.c
 
 .PHONY: win64
 win64: 
-	x86_64-w64-mingw32-gcc-win32 -Ofast -D_WIN32 -o run.exe -I. run.c win.c
+	x86_64-w64-mingw32-gcc -Ofast -D_WIN32 -o run.exe -I. run.c win.c
 
 # compiles with gnu99 standard flags for amazon linux, coreos, etc. compatibility
 .PHONY: rungnu


### PR DESCRIPTION
**Fix: Use correct compiler for Win64 GCC in Makefile**

**Description:**
This PR fixes the Makefile to use the appropriate compiler for Win64 GCC. The original line used 'x86_64-w64-mingw32-gcc-win32', which is incorrect when using MSYS2. The correct executable name for MSYS2 is 'x86_64-w64-mingw32-gcc', which is now updated in the Makefile.

**Changes Made:**
- Modified the Makefile to use 'x86_64-w64-mingw32-gcc' for building on Win64 GCC.

**Testing:**
I tested the changes locally on my system to ensure that the Makefile builds the 'run.exe' executable correctly using the correct compiler.

Thanks for considering this PR.
