### PR TITLE
Add llama2.js to notable forks section

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ If your candidate PRs have elements of these it doesn't mean they won't get merg
 - [llama2.go](https://github.com/saracen/llama2.go) by @saracen: a Go port of this project
 - [llama2.c-android](https://github.com/Manuel030/llama2.c-android): by @Manuel030: adds Android binaries of this project
 - [llama2.cpp](https://github.com/leloykun/llama2.cpp) by @leloykun: a C++ port of this project
+- [llama2.js](https://github.com/epicure/llama2.js) by @epicure: a JavaScript port of this project
 
 ## unsorted todos
 


### PR DESCRIPTION
Adds a link to my [JavaScript port](https://github.com/epicure/llama2.js) of this repo