### PR TITLE
Parallelize pretokenizer in multiple processes to boost performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,12 @@ python tinystories.py download
 python tinystories.py pretokenize
 ```
 
+You can also change parallel setting of the pretokenizer for better performance by
+```bash
+python tinystories.py pretokenize 4 # Do pretokenize in parallel in 4 processes
+```
+Be careful not to set the parallel level too high as it may lock your system up. The "right" setting depends on many things e.g., the total number of physical/virtual cores or the overall loading of the system etc. In general, setting this value to be a little lower than the physical CPU cores on your system would be safe.
+
 Then train our model:
 
 ```bash


### PR DESCRIPTION
The python GIL (global interpreter lock) is holding back the parallelism of pretokenizer under ThreadPoolExecutor. Switch to ProcessPoolExecutor to eliminate GIL effect and enhance parallelism hence boost performance Unfortunately, the "right" parallel level setting depends on many things e.g., the total number of physical/virtual cores and the overall loading of the system etc. And too high setting may lock up the system. Thereby, add a new user setting for 'parallelism' for the user to choose at discretion with default set to 1 for safety.