### PR TITLE
Switch to fast floating point model and turn off floating point exceptions for MSVC build

### DIFF
--- a/build_msvc.bat
+++ b/build_msvc.bat
@@ -1,1 +1,1 @@
-cl.exe /Ox /openmp /I. run.c win.c
+cl.exe /Ox /fp:fast /fp:except- /openmp /I. run.c win.c


### PR DESCRIPTION
Changing these build flags increases the achieved tokens per second on my computer from around 18 to around 21.