### PR TITLE
use ssize_t/int64 and 64bit version of ftell on windows

### DIFF
--- a/run.c
+++ b/run.c
@@ -483,7 +483,7 @@ int main(int argc, char *argv[]) {
     TransformerWeights weights;
     int fd = 0;         // file descriptor for memory mapping
     float* data = NULL; // memory mapped data pointer
-    long file_size;     // size of the checkpoint file in bytes
+    ssize_t file_size;     // size of the checkpoint file in bytes
     {
         FILE *file = fopen(checkpoint, "rb");
         if (!file) { printf("Couldn't open file %s\n", checkpoint); return 1; }

--- a/win.c
+++ b/win.c
@@ -2,7 +2,6 @@
 #include <errno.h>
 #include <io.h>
 
-
 #ifndef FILE_MAP_EXECUTE
 #define FILE_MAP_EXECUTE    0x0020
 #endif /* FILE_MAP_EXECUTE */
@@ -53,10 +52,9 @@ static DWORD __map_mmap_prot_file(const int prot)
     return desiredAccess;
 }
 
-void* mmap(void *addr, size_t len, int prot, int flags, int fildes, off_t off)
+void* mmap(void *addr, size_t len, int prot, int flags, int fildes, ssize_t off)
 {
     HANDLE fm, h;
-    
     void * map = MAP_FAILED;
     
 #ifdef _MSC_VER
@@ -64,18 +62,18 @@ void* mmap(void *addr, size_t len, int prot, int flags, int fildes, off_t off)
 #pragma warning(disable: 4293)
 #endif
 
-    const DWORD dwFileOffsetLow = (sizeof(off_t) <= sizeof(DWORD)) ? 
+    const DWORD dwFileOffsetLow = (sizeof(ssize_t) <= sizeof(DWORD)) ? 
                     (DWORD)off : (DWORD)(off & 0xFFFFFFFFL);
-    const DWORD dwFileOffsetHigh = (sizeof(off_t) <= sizeof(DWORD)) ?
+    const DWORD dwFileOffsetHigh = (sizeof(ssize_t) <= sizeof(DWORD)) ?
                     (DWORD)0 : (DWORD)((off >> 32) & 0xFFFFFFFFL);
     const DWORD protect = __map_mmap_prot_page(prot);
     const DWORD desiredAccess = __map_mmap_prot_file(prot);
 
-    const off_t maxSize = off + (off_t)len;
+    const ssize_t maxSize = off + (ssize_t)len;
 
-    const DWORD dwMaxSizeLow = (sizeof(off_t) <= sizeof(DWORD)) ? 
+    const DWORD dwMaxSizeLow = (sizeof(ssize_t) <= sizeof(DWORD)) ? 
                     (DWORD)maxSize : (DWORD)(maxSize & 0xFFFFFFFFL);
-    const DWORD dwMaxSizeHigh = (sizeof(off_t) <= sizeof(DWORD)) ?
+    const DWORD dwMaxSizeHigh = (sizeof(ssize_t) <= sizeof(DWORD)) ?
                     (DWORD)0 : (DWORD)((maxSize >> 32) & 0xFFFFFFFFL);
 
 #ifdef _MSC_VER

--- a/win.c
+++ b/win.c
@@ -62,19 +62,15 @@ void* mmap(void *addr, size_t len, int prot, int flags, int fildes, ssize_t off)
 #pragma warning(disable: 4293)
 #endif
 
-    const DWORD dwFileOffsetLow = (sizeof(ssize_t) <= sizeof(DWORD)) ? 
-                    (DWORD)off : (DWORD)(off & 0xFFFFFFFFL);
-    const DWORD dwFileOffsetHigh = (sizeof(ssize_t) <= sizeof(DWORD)) ?
-                    (DWORD)0 : (DWORD)((off >> 32) & 0xFFFFFFFFL);
+    const DWORD dwFileOffsetLow = (DWORD)(off & 0xFFFFFFFFL);
+    const DWORD dwFileOffsetHigh = (DWORD)((off >> 32) & 0xFFFFFFFFL);
     const DWORD protect = __map_mmap_prot_page(prot);
     const DWORD desiredAccess = __map_mmap_prot_file(prot);
 
     const ssize_t maxSize = off + (ssize_t)len;
 
-    const DWORD dwMaxSizeLow = (sizeof(ssize_t) <= sizeof(DWORD)) ? 
-                    (DWORD)maxSize : (DWORD)(maxSize & 0xFFFFFFFFL);
-    const DWORD dwMaxSizeHigh = (sizeof(ssize_t) <= sizeof(DWORD)) ?
-                    (DWORD)0 : (DWORD)((maxSize >> 32) & 0xFFFFFFFFL);
+    const DWORD dwMaxSizeLow = (DWORD)(maxSize & 0xFFFFFFFFL);
+    const DWORD dwMaxSizeHigh = (DWORD)((maxSize >> 32) & 0xFFFFFFFFL);
 
 #ifdef _MSC_VER
 #pragma warning(pop)
@@ -108,11 +104,11 @@ void* mmap(void *addr, size_t len, int prot, int flags, int fildes, ssize_t off)
         errno = __map_mman_error(GetLastError(), EPERM);
         return MAP_FAILED;
     }
-  
+
     map = MapViewOfFile(fm, desiredAccess, dwFileOffsetHigh, dwFileOffsetLow, len);
 
     CloseHandle(fm);
-  
+
     if (map == NULL)
     {
         errno = __map_mman_error(GetLastError(), EPERM);

--- a/win.h
+++ b/win.h
@@ -5,6 +5,8 @@
 #include <windows.h>
 #include <time.h>
 
+#define ssize_t __int64
+#define ftell _ftelli64
 
 // Below code is originally from mman-win32
 //

--- a/win.h
+++ b/win.h
@@ -53,7 +53,7 @@ extern "C" {
 /* Flags for portable clock_gettime call. */
 #define CLOCK_REALTIME  0
 
-void*   mmap(void *addr, size_t len, int prot, int flags, int fildes, off_t off);
+void*   mmap(void *addr, size_t len, int prot, int flags, int fildes, ssize_t off);
 int     munmap(void *addr, size_t len);
 int     mprotect(void *addr, size_t len, int prot);
 int     msync(void *addr, size_t len, int flags);


### PR DESCRIPTION
On Windows, there is a separate API for ftell on 64bit, in addition due to long type being 32bit on Windows, switch to ssize_t 