### PR TITLE
Add another Rust port in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ If your candidate PRs have elements of these it doesn't mean they won't get merg
 - [llama2.cpp](https://github.com/leloykun/llama2.cpp) by @leloykun: a C++ port of this project
 - [llama2.js](https://github.com/epicure/llama2.js) by @epicure: a JavaScript port of this project
 - [llama2.zig](https://github.com/cgbur/llama2.zig) by @cgbur: A Zig port of this project
+- [llama2.rs](https://github.com/leo-du/llama2.rs) by @leo-du: A Rust port of this project
 
 ## unsorted todos
 


### PR DESCRIPTION
Add a link to another Rust port. Difference with the existing Rust port including:

* *zero* dependencies: current Rust ports needs a number of dependencies, this port is self-sufficient -- just compile and run!
* *zero* lines of unsafe code: unlike the existing port, this port contains zero lines of `unsafe` code block and is fully memory safe
* supports BPE encoding user prompts (existing port has no BPE support yet)