### PR TITLE
run.c - Speed up with output buffering

### DIFF
--- a/run.c
+++ b/run.c
@@ -548,8 +548,7 @@ int main(int argc, char *argv[]) {
     int token = 1;   // init with token 1 (=BOS), as done in Llama-2 sentencepiece tokenizer
     int pos = 0;     // position in the sequence
     int bufferflush = 1; // buffer flush after token counter 
-    char outbuff[4096]; // used for output buffering              
-    memset( outbuff, '\0', sizeof( outbuff )); // clear buffer area
+    static char outbuff[4096]; // used for output buffering              
     printf("<s>\n"); // explicit print the initial BOS token for stylistic symmetry reasons
     setvbuf(stdout, outbuff, _IOFBF, 4096); // setup output buffering
     while (pos < steps) {
@@ -578,7 +577,7 @@ int main(int argc, char *argv[]) {
         // following BOS token (1), sentencepiece decoder strips any leading whitespace (see PR #89)
         char *token_str = (token == 1 && vocab[next][0] == ' ') ? vocab[next]+1 : vocab[next];
         printf("%s", token_str);
-        if (bufferflush==pos) { fflush(stdout); bufferflush+=buffertokens; } // flush after every n tokens
+        if (bufferflush==pos && strlen(outbuff)<=4096) { fflush(stdout); bufferflush+=buffertokens; } // flush after every n tokens
 
         // advance forward
         token = next;

--- a/run.c
+++ b/run.c
@@ -548,7 +548,7 @@ int main(int argc, char *argv[]) {
     int token = 1;   // init with token 1 (=BOS), as done in Llama-2 sentencepiece tokenizer
     int pos = 0;     // position in the sequence
     int bufferflush = 1; // token counter for flushing buffer
-    char outbuff[config.seq_len * (6 + 2)]; // buffersize is context length * average size of subwords + margin
+    char outbuff[4096 * (6 + 2)] ; // buffersize is context length * average size of subwords + margin
     printf("<s>\n"); // explicit print the initial BOS token for stylistic symmetry reasons
 
     // setvbuf is used to buffer output into outbuff instead of flushing to screen directly

--- a/run.c
+++ b/run.c
@@ -548,7 +548,7 @@ int main(int argc, char *argv[]) {
     int token = 1;   // init with token 1 (=BOS), as done in Llama-2 sentencepiece tokenizer
     int pos = 0;     // position in the sequence
     int bufferflush = 1; // token counter for flushing buffer
-    char outbuff[4096 * (6 + 2)] ; // buffersize is context length * average size of subwords + margin
+    static char outbuff[4096 * (6 + 2)] ; // buffersize is context length * average size of subwords + margin
     printf("<s>\n"); // explicit print the initial BOS token for stylistic symmetry reasons
 
     // setvbuf is used to buffer output into outbuff instead of flushing to screen directly

--- a/run.c
+++ b/run.c
@@ -548,10 +548,10 @@ int main(int argc, char *argv[]) {
     int token = 1;   // init with token 1 (=BOS), as done in Llama-2 sentencepiece tokenizer
     int pos = 0;     // position in the sequence
     int bufferflush = 1; // buffer flush after token counter 
-    char outbuff[2048]; // used for output buffering              
+    char outbuff[4096]; // used for output buffering              
     memset( outbuff, '\0', sizeof( outbuff )); // clear buffer area
     printf("<s>\n"); // explicit print the initial BOS token for stylistic symmetry reasons
-    setvbuf(stdout, outbuff, _IOFBF, 2048); // setup output buffering
+    setvbuf(stdout, outbuff, _IOFBF, 4096); // setup output buffering
     while (pos < steps) {
 
         // forward the transformer to get logits for the next token


### PR DESCRIPTION
Previously much of time was spent writing to screen which is relatively slow.

By enabling output buffering more work can be performed by writing groups of computed tokens to the buffer which is relatively fast, and then flushing the buffer periodically to screen/console.

Testing with the smallest model, a interactive tokens/s speed up of ~14% on standard builds to ~84% on open-mp builds has been achieved.

```
Usage:

run <checkpoint_file> [temperature] [steps] [prompt] [buffer_tokens]

Where buffer_tokens is the number of tokens to be buffered.
```

Multiples of 2 seem to be ideal. 64 worked well for my use case on a low end machine.

The speed up may depend on model size and OS.

Example:

```
./run model.bin 0 0 "A car" 64
```
