### PR TITLE
added JNI for android with compiler optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ If your candidate PRs have elements of these it doesn't mean they won't get merg
 - [llama2.go](https://github.com/haormj/llama2.go) by @haormj: a Go port of this project
 - [llama2.go](https://github.com/saracen/llama2.go) by @saracen: a Go port of this project
 - [llama2.c-android](https://github.com/Manuel030/llama2.c-android): by @Manuel030: adds Android binaries of this project
+- [llama2.c-android-wrapper](https://github.com/celikin/llama2.c-android-wrapper): by @celikin: added JNI wrapper, PoC
 - [llama2.cpp](https://github.com/leloykun/llama2.cpp) by @leloykun: a C++ port of this project
 
 ## unsorted todos


### PR DESCRIPTION
Added JNI interface to Android app and enable -Ofast and openMP in a library. I got approx 90 tokens/sec with optimizations on Pixel 7 Pro (without optimization approx 16 tokens/sec)
[Screen_recording_20230728_121057.webm](https://github.com/karpathy/llama2.c/assets/7045168/342d1d1b-adc5-454a-9185-ab8caf37f792)

full code in an android branch:
https://github.com/celikin/llama2.c-android-wrapper

UPD:
increased openMP threads to 4. and I got tok/s: 205.479452