### PR TITLE
Adjust `malloc` size for `prompt_tokens`

### DIFF
--- a/run.c
+++ b/run.c
@@ -534,7 +534,7 @@ int main(int argc, char *argv[]) {
     int *prompt_tokens = NULL;
     int num_prompt_tokens = 0;
     if (prompt != NULL) {
-        prompt_tokens = (int*)malloc(config.seq_len * sizeof(int));
+        prompt_tokens = (int*)malloc(strlen(prompt) * sizeof(int));
         bpe_encode(prompt, vocab, vocab_scores, config.vocab_size, max_token_length, prompt_tokens, &num_prompt_tokens);
     }
 


### PR DESCRIPTION
This pull request addresses a potential memory optimization when calling the `bpe_encode` function.

The function currently reserves memory for the `prompt_tokens` array using a size derived from `config.seq_len`, independent of the actual size of the `prompt`. This could lead to a situation where the allocated memory size is either too large (leading to inefficient usage of memory) or even too small if the `prompt` has more characters than `config.seq_len` (potentially resulting in buffer overflow).

This PR proposes to change the `malloc` call from
- `(int*)malloc(config.seq_len * sizeof(int))` to 
- `(int*)malloc(strlen(prompt) * sizeof(int))`

This ensures that the allocated memory is directly proportional to the size of the `prompt`.