### PR TITLE
Scala port

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ If your candidate PRs have elements of these it doesn't mean they won't get merg
 - [llama2.cpp](https://github.com/leloykun/llama2.cpp) by @leloykun: a C++ port of this project
 - [llama2.js](https://github.com/epicure/llama2.js) by @epicure: a JavaScript port of this project
 - [llama2.zig](https://github.com/cgbur/llama2.zig) by @cgbur: A Zig port of this project
+- [llama2.scala](https://github.com/jrudolph/llama2.scala) by @jrudolph: a Scala port of this project
 
 ## unsorted todos
 


### PR DESCRIPTION
Not sure this is notable, so far it's a straight port from your C code to Scala.

I was interested in how bad the performance would be on the JVM compared to C. The best single-threaded run so far is only 5-10% slower than your vanilla C performance which sounds pretty good (before any optimizations).

More of a notification about the presence of this port than a serious attempt to getting this merged :)