### PR TITLE
Refactor RoPE code using complex

### DIFF
--- a/run.c
+++ b/run.c
@@ -14,6 +14,7 @@ $ ./run
 #include <math.h>
 #include <string.h>
 #include <fcntl.h>
+#include <complex.h>
 #if defined _WIN32
     #include "win.h"
 #else

--- a/run.c
+++ b/run.c
@@ -234,7 +234,6 @@ void transformer(int token, int pos, Config* p, RunState* s, TransformerWeights*
         matmul(s->v, s->xb, w->wv + l*dim*dim, dim, dim);
 
         // apply RoPE rotation to the q and k vectors for each head
-        // rotate q and k by the freq_cis_real and freq_cis_imag
         int freq_cis_size = head_size / 2;
         for (int h = 0; h < p->n_heads; h++) {
             // get the q and k complex vectors for this head

--- a/run.c
+++ b/run.c
@@ -235,10 +235,10 @@ void transformer(int token, int pos, Config* p, RunState* s, TransformerWeights*
 
         // apply RoPE rotation to the q and k vectors for each head
         // rotate q and k by the freq_cis_real and freq_cis_imag
-        float _Complex* q_c = (float _Complex*)s->q;
-        float _Complex* k_c = (float _Complex*)s->k;
+        float complex* q_c = (float complex*)s->q;
+        float complex* k_c = (float complex*)s->k;
         for (int i = 0; i < p->n_heads * head_size / 2; i++) {
-            float _Complex f = freq_cis_real_row[i] + freq_cis_imag_row[i] * I;
+            float complex f = freq_cis_real_row[i % (head_size / 2)] + freq_cis_imag_row[i % (head_size / 2)] * I;
             q_c[i] *= f;
             k_c[i] *= f;
         }

--- a/run.c
+++ b/run.c
@@ -233,23 +233,18 @@ void transformer(int token, int pos, Config* p, RunState* s, TransformerWeights*
         matmul(s->v, s->xb, w->wv + l*dim*dim, dim, dim);
 
         // apply RoPE rotation to the q and k vectors for each head
-        for (int h = 0; h < p->n_heads; h++) {
-            // get the q and k vectors for this head
-            float* q = s->q + h * head_size;
-            float* k = s->k + h * head_size;
-            // rotate q and k by the freq_cis_real and freq_cis_imag
-            for (int i = 0; i < head_size; i+=2) {
-                float q0 = q[i];
-                float q1 = q[i+1];
-                float k0 = k[i];
-                float k1 = k[i+1];
-                float fcr = freq_cis_real_row[i/2];
-                float fci = freq_cis_imag_row[i/2];
-                q[i]   = q0 * fcr - q1 * fci;
-                q[i+1] = q0 * fci + q1 * fcr;
-                k[i]   = k0 * fcr - k1 * fci;
-                k[i+1] = k0 * fci + k1 * fcr;
-            }
+        // rotate q and k by the freq_cis_real and freq_cis_imag
+        for (int i = 0; i < p->n_heads * head_size; i+=2) {
+            float q0 = s->q[i];
+            float q1 = s->q[i+1];
+            float k0 = s->k[i];
+            float k1 = s->k[i+1];
+            float fcr = freq_cis_real_row[(i % head_size) / 2];
+            float fci = freq_cis_imag_row[(i % head_size) / 2];
+            s->q[i]   = q0 * fcr - q1 * fci;
+            s->q[i+1] = q0 * fci + q1 * fcr;
+            s->k[i]   = k0 * fcr - k1 * fci;
+            s->k[i+1] = k0 * fci + k1 * fcr;
         }
 
         // save key,value at this time step (pos) to our kv cache

--- a/run.c
+++ b/run.c
@@ -52,8 +52,8 @@ typedef struct {
     // final rmsnorm
     float* rms_final_weight; // (dim,)
     // freq_cis for RoPE relatively positional embeddings
-    float* freq_cis_real; // (seq_len, dim/2)
-    float* freq_cis_imag; // (seq_len, dim/2)
+    float* freq_cis_real; // (seq_len, dim/n_heads/2)
+    float* freq_cis_imag; // (seq_len, dim/n_heads/2)
     // (optional) classifier weights for the logits, on the last layer
     float* wcls;
 } TransformerWeights;
@@ -237,8 +237,10 @@ void transformer(int token, int pos, Config* p, RunState* s, TransformerWeights*
         // rotate q and k by the freq_cis_real and freq_cis_imag
         int freq_cis_size = head_size / 2;
         for (int h = 0; h < p->n_heads; h++) {
+            // get the q and k complex vectors for this head
             float complex* q_c = (float complex*)(s->q + h * head_size);
             float complex* k_c = (float complex*)(s->k + h * head_size);
+            // rotate q and k by the freq_cis_real and freq_cis_imag
             for (int i = 0; i < freq_cis_size; i++) {
                 float complex f = freq_cis_real_row[i] + freq_cis_imag_row[i] * I;
                 q_c[i] *= f;

--- a/run.c
+++ b/run.c
@@ -235,12 +235,15 @@ void transformer(int token, int pos, Config* p, RunState* s, TransformerWeights*
 
         // apply RoPE rotation to the q and k vectors for each head
         // rotate q and k by the freq_cis_real and freq_cis_imag
-        float complex* q_c = (float complex*)s->q;
-        float complex* k_c = (float complex*)s->k;
-        for (int i = 0; i < p->n_heads * head_size / 2; i++) {
-            float complex f = freq_cis_real_row[i % (head_size / 2)] + freq_cis_imag_row[i % (head_size / 2)] * I;
-            q_c[i] *= f;
-            k_c[i] *= f;
+        int freq_cis_size = head_size / 2;
+        for (int h = 0; h < p->n_heads; h++) {
+            float complex* q_c = (float complex*)(s->q + h * head_size);
+            float complex* k_c = (float complex*)(s->k + h * head_size);
+            for (int i = 0; i < freq_cis_size; i++) {
+                float complex f = freq_cis_real_row[i] + freq_cis_imag_row[i] * I;
+                q_c[i] *= f;
+                k_c[i] *= f;
+            }
         }
 
         // save key,value at this time step (pos) to our kv cache


### PR DESCRIPTION
This commit use complex to refactor the code responsible for RoPE. Instead of using a nested loop over the number of heads, it now utilizes a single loop iterating over the combined size of the heads and the head size. This modification improves code readability and makes the code more amenable to parallelization.