### PR TITLE
adding PGO optimizations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,15 @@ rundebug: run.c
 runfast: run.c
 	$(CC) -Ofast -o run run.c -lm
 
+# on macos you'll need to have llvm installed, and in your path '''brew install llvm'''
+# export PATH="/opt/homebrew/opt/llvm/bin:$PATH"
+.PHONY: runfastpgo
+runfast: run.c
+	$(CC) -Ofast -fprofile-instr-generate -o run run.c -lm
+	./run stories15M.bin
+	xcrun llvm-profdata merge -sparse default.profraw -o default.profdata
+	$(CC) -Ofast -fprofile-instr-use=default.profdata -o run run.c -lm
+
 # additionally compiles with OpenMP, allowing multithreaded runs
 # make sure to also enable multiple threads when running, e.g.:
 # OMP_NUM_THREADS=4 ./run out/model.bin
@@ -48,3 +57,6 @@ runompgnu:
 .PHONY: clean
 clean:
 	rm -f run
+	rm -f *.profdata
+	rm -f *.profraw
+

--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ gcc -O3 -o run run.c -lm
 
 To get a much better performance, try to compile with `make runfast`. This turns on the `-Ofast` flag, which includes additional optimizations that may break compliance with the C/IEEE specifications, in addition to `-O3`. See [the GCC docs](https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html) for more information.
 
+To use make runfast with PGO optimizations compile with make runfastpgo. This didnt make any noticable different on m1. 
+
 Try `-march=native` to compile the program to use the architecture of the machine you're compiling on rather than a more generic CPU. This may enable additional optimizations and hardware-specific tuning such as improved vector instructions/width.
 
 The fastest throughput I saw so far on my MacBook Air (M1) so far is with `make runfast`. 


### PR DESCRIPTION
```
.PHONY: runfastpgo
runfast: run.c
	$(CC) -Ofast -fprofile-instr-generate -o run run.c -lm
	./run stories15M.bin
	xcrun llvm-profdata merge -sparse default.profraw -o default.profdata
	$(CC) -Ofast -fprofile-instr-use=default.profdata -o run run.c -lm
```

No noticeable speed difference from runfast on m1 max, but may generally be useful, maybe with different/larger weights or larger runs. Only tested on the default run