### PR TITLE
run.c - Enhance arg parse : optional parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,24 +20,31 @@ Compile and run the C code:
 
 ```bash
 make run
-./run stories15M.bin
+./run -c stories15M.bin
 ```
 
 You'll see the text stream a sample. On my M1 MacBook Air this runs at ~110 tokens/s. See [performance](#performance) or the Makefile for compile flags that can significantly speed this up. We can also try a bit bigger 42M parameter model:
 
 ```bash
 wget https://huggingface.co/karpathy/tinyllamas/resolve/main/stories42M.bin
-./run stories42M.bin
+./run -c stories42M.bin
 ```
 
 This still runs at interactive rates and samples more coherent and diverse stories:
 
 > Once upon a time, there was a little girl named Lily. She loved playing with her toys on top of her bed. One day, she decided to have a tea party with her stuffed animals. She poured some tea into a tiny teapot and put it on top of the teapot. Suddenly, her little brother Max came into the room and wanted to join the tea party too. Lily didn't want to share her tea and she told Max to go away. Max started to cry and Lily felt bad. She decided to yield her tea party to Max and they both shared the teapot. But then, something unexpected happened. The teapot started to shake and wiggle. Lily and Max were scared and didn't know what to do. Suddenly, the teapot started to fly towards the ceiling and landed on the top of the bed. Lily and Max were amazed and they hugged each other. They realized that sharing was much more fun than being selfish. From that day on, they always shared their tea parties and toys.
 
-You can also prompt the model with a prefix (sadly, because this is currently done via positional arguments, you also have to specify temperature 1.0 and 256 steps, before you enter the prompt):
+You can also prompt the model with a prefix:
 
 ```bash
-./run stories42M.bin 1.0 256 "One day, Lily met a Shoggoth"
+./run -c stories42M.bin -p "One day, Lily met a Shoggoth"
+```
+
+You can also specify temperature and steps to limit output, before you enter the prompt:
+
+```bash
+./run -c stories42M.bin -t 1.0 -s 256 -p "One day, Lily met a Shoggoth"
+
 ```
 
 > One day, Lily met a Shoggoth. He was very shy, but was also very generous. Lily said “Hello Shoggy! Can I be your friend?” Shoggy was happy to have a friend and said “Yes, let’s explore the universe together!” So they set off on a journey to explore the universe. As they travelled, Shoggy was happy to explain to Lily about all the wonderful things in the universe. At the end of the day, Lily and Shoggy had gathered lots of wonderful things from the universe, and they both felt very proud. They promised to explore the universe as one big pair and to never stop being generous to each other.
@@ -56,7 +63,7 @@ python export_meta_llama_bin.py path/to/llama/model/7B llama2_7b.bin
 The export will take ~10 minutes or so and generate a 26GB file (the weights of the 7B model in float32) called `llama2_7b.bin` in the current directory. It has been [reported](https://github.com/karpathy/llama2.c/pull/85) that despite efforts, the 13B export currently doesn't work for unknown reaons (accepting PRs for fix). We can run the model as normal:
 
 ```bash
-./run llama2_7b.bin
+./run -c llama2_7b.bin
 ```
 
 This ran at about 4 tokens/s compiled with [OpenMP](#OpenMP) on 96 threads on my CPU Linux box in the cloud. (On my MacBook Air M1, currently it's closer to 30 seconds per token if you just build with `make runfast`.) Example output:
@@ -109,7 +116,7 @@ make run
 You can now run it simply as
 
 ```bash
-./run stories15M.bin
+./run -c stories15M.bin
 ```
 
 Watch the tokens stream by, fun! We can also run the PyTorch inference script for a comparison. Download one of the models again from huggingface hub and point the `sample.py` script at it:
@@ -157,7 +164,7 @@ clang -Ofast -fopenmp -march=native run.c  -lm  -o run
 When you run inference make sure to use OpenMP flags to set the number of threads, e.g.:
 
 ```bash
-OMP_NUM_THREADS=4 ./run out/model.bin
+OMP_NUM_THREADS=4 ./run -c out/model.bin
 ```
 
 Depending on your system resources you may want to tweak these hyperparameters and use more threads. But more is not always better, usually this is a bit U shaped.

--- a/README.md
+++ b/README.md
@@ -20,14 +20,14 @@ Compile and run the C code:
 
 ```bash
 make run
-./run -c stories15M.bin
+./run stories15M.bin
 ```
 
 You'll see the text stream a sample. On my M1 MacBook Air this runs at ~110 tokens/s. See [performance](#performance) or the Makefile for compile flags that can significantly speed this up. We can also try a bit bigger 42M parameter model:
 
 ```bash
 wget https://huggingface.co/karpathy/tinyllamas/resolve/main/stories42M.bin
-./run -c stories42M.bin
+./run stories42M.bin
 ```
 
 This still runs at interactive rates and samples more coherent and diverse stories:
@@ -37,13 +37,13 @@ This still runs at interactive rates and samples more coherent and diverse stori
 You can also prompt the model with a prefix:
 
 ```bash
-./run -c stories42M.bin -p "One day, Lily met a Shoggoth"
+./run stories42M.bin -p "One day, Lily met a Shoggoth"
 ```
 
 You can also specify temperature and steps to limit output, before you enter the prompt:
 
 ```bash
-./run -c stories42M.bin -t 1.0 -s 256 -p "One day, Lily met a Shoggoth"
+./run stories42M.bin -t 1.0 -s 256 -p "One day, Lily met a Shoggoth"
 
 ```
 
@@ -63,7 +63,7 @@ python export_meta_llama_bin.py path/to/llama/model/7B llama2_7b.bin
 The export will take ~10 minutes or so and generate a 26GB file (the weights of the 7B model in float32) called `llama2_7b.bin` in the current directory. It has been [reported](https://github.com/karpathy/llama2.c/pull/85) that despite efforts, the 13B export currently doesn't work for unknown reaons (accepting PRs for fix). We can run the model as normal:
 
 ```bash
-./run -c llama2_7b.bin
+./run llama2_7b.bin
 ```
 
 This ran at about 4 tokens/s compiled with [OpenMP](#OpenMP) on 96 threads on my CPU Linux box in the cloud. (On my MacBook Air M1, currently it's closer to 30 seconds per token if you just build with `make runfast`.) Example output:
@@ -116,7 +116,7 @@ make run
 You can now run it simply as
 
 ```bash
-./run -c stories15M.bin
+./run stories15M.bin
 ```
 
 Watch the tokens stream by, fun! We can also run the PyTorch inference script for a comparison. Download one of the models again from huggingface hub and point the `sample.py` script at it:
@@ -164,7 +164,7 @@ clang -Ofast -fopenmp -march=native run.c  -lm  -o run
 When you run inference make sure to use OpenMP flags to set the number of threads, e.g.:
 
 ```bash
-OMP_NUM_THREADS=4 ./run -c out/model.bin
+OMP_NUM_THREADS=4 ./run out/model.bin
 ```
 
 Depending on your system resources you may want to tweak these hyperparameters and use more threads. But more is not always better, usually this is a bit U shaped.

--- a/run.c
+++ b/run.c
@@ -456,11 +456,16 @@ int main(int argc, char *argv[]) {
     int steps = 256;          // max number of steps to run for, 0: use seq_len
     char *prompt = NULL;      // prompt string
 
-    for (int i = 1; i < argc; i++) {
+    // 'checkpoint' is necessary arg
+    if (argc < 2) {
+        printf("Usage: %s <checkpoint_file> \n", argv[0]);
+        exit(EXIT_FAILURE);
+    }    
+    if (argc >= 2) { checkpoint = argv[1]; }
+    for (int i = 2; i < argc; i++) {
         switch (argv[i][0]) {
             case '-':
                 switch (argv[i][1]) {
-                    case 'c': if (i + 1 < argc) { checkpoint = argv[++i]; }             break;
                     // optional temperature. 0.0 = (deterministic) argmax sampling. 1.0 = baseline
                     case 't': if (i + 1 < argc) { temperature = atof(argv[++i]); }	break;
                     case 's': if (i + 1 < argc) { steps = atoi(argv[++i]); }            break;
@@ -469,14 +474,9 @@ int main(int argc, char *argv[]) {
                     exit(EXIT_FAILURE);
                 } break;
             default:
-            printf("Usage: %s -c <checkpoint_file> -t [temperature] -s [steps] -p [prompt] \n", argv[0]);
+            printf("Usage: %s <checkpoint_file> -t [temperature] -s [steps] -p [prompt] \n", argv[0]);
             exit(EXIT_FAILURE);
         }
-    }
-    // 'checkpoint' is necessary arg
-    if (checkpoint == NULL) {
-        printf("Error: checkpoint file (model) not set. \nSet with %s -c <checkpoint_file>\n",argv[0]);
-        exit(EXIT_FAILURE);
     }
 
     // seed rng with time. if you want deterministic behavior use temperature 0.0

--- a/run.c
+++ b/run.c
@@ -456,23 +456,27 @@ int main(int argc, char *argv[]) {
     int steps = 256;          // max number of steps to run for, 0: use seq_len
     char *prompt = NULL;      // prompt string
 
+    for (int i = 1; i < argc; i++) {
+        switch (argv[i][0]) {
+            case '-':
+                switch (argv[i][1]) {
+                    case 'c': if (i + 1 < argc) { checkpoint = argv[++i]; }             break;
+                    // optional temperature. 0.0 = (deterministic) argmax sampling. 1.0 = baseline
+                    case 't': if (i + 1 < argc) { temperature = atof(argv[++i]); }	break;
+                    case 's': if (i + 1 < argc) { steps = atoi(argv[++i]); }            break;
+                    case 'p': if (i + 1 < argc) { prompt = argv[++i]; }                 break;
+                    default: printf("Invalid option: %s\n", argv[i]); 
+                    exit(EXIT_FAILURE);
+                } break;
+            default:
+            printf("Usage: %s -c <checkpoint_file> -t [temperature] -s [steps] -p [prompt] \n", argv[0]);
+            exit(EXIT_FAILURE);
+        }
+    }
     // 'checkpoint' is necessary arg
-    if (argc < 2) {
-        printf("Usage: %s <checkpoint_file> [temperature] [steps] [prompt]\n", argv[0]);
-        return 1;
-    }
-    if (argc >= 2) {
-        checkpoint = argv[1];
-    }
-    if (argc >= 3) {
-        // optional temperature. 0.0 = (deterministic) argmax sampling. 1.0 = baseline
-        temperature = atof(argv[2]);
-    }
-    if (argc >= 4) {
-        steps = atoi(argv[3]);
-    }
-    if (argc >= 5) {
-        prompt = argv[4];
+    if (checkpoint == NULL) {
+        printf("Error: checkpoint file (model) not set. \nSet with %s -c <checkpoint_file>\n",argv[0]);
+        exit(EXIT_FAILURE);
     }
 
     // seed rng with time. if you want deterministic behavior use temperature 0.0


### PR DESCRIPTION
It would be ideal to specify parameters without having to set all. One could use getopt for that but it is not portable. So we roll our own minimal one.

Usage:

```bash
run <checkpoint_file> -t [temperature] -s [steps] -p [prompt]
```

Minimum:

```bash
run <checkpoint_file>
```

The following are optional:

-t [temperature] -s [steps] -p [prompt]

if they are omitted, default values are used.

The order of -t -s -p does not matter but the checkpoint_file has to be the first parameter.

To keep it simple without needing for extended checks, if the parameter to the last option is missing, the current default value is used instead.

Updated README.MD to reflect changes.

Incorporated requirement from: https://github.com/karpathy/llama2.c/pull/218#issuecomment-1662596666