### PR TITLE
Fixing max_seq_len passed to RoPE implementation. Minor comment changes 

### DIFF
--- a/model.py
+++ b/model.py
@@ -216,7 +216,7 @@ class Transformer(nn.Module):
         self.tok_embeddings.weight = self.output.weight # https://paperswithcode.com/method/weight-tying
 
         # some useful precompute for the RoPE relative positional embeddings. TODO why * 2 here? confuse
-        freqs_cos, freqs_sin = precompute_freqs_cis(self.params.dim // self.params.n_heads, self.params.max_seq_len * 2)
+        freqs_cos, freqs_sin = precompute_freqs_cis(self.params.dim // self.params.n_heads, self.params.max_seq_len)
         self.register_buffer("freqs_cos", freqs_cos, persistent=False)
         self.register_buffer("freqs_sin", freqs_sin, persistent=False)
         

--- a/run.c
+++ b/run.c
@@ -51,8 +51,8 @@ typedef struct {
     // final rmsnorm
     float* rms_final_weight; // (dim,)
     // freq_cis for RoPE relatively positional embeddings
-    float* freq_cis_real; // (seq_len, dim/2)
-    float* freq_cis_imag; // (seq_len, dim/2)
+    float* freq_cis_real; // (seq_len, head_size/2)
+    float* freq_cis_imag; // (seq_len, head_size/2)
     // (optional) classifier weights for the logits, on the last layer
     float* wcls;
 } TransformerWeights;


### PR DESCRIPTION
https://github.com/karpathy/llama2.c/blob/af8708d87bcda7fda97b93f6c135dd43ea78106c/model.py#L218-L219

We pass 2*max_seq_length but for all forward passes & while saving model we truncate it to first `:max_seq_length` elements. 

I don't see this in reference huggingface [implementation](https://github.com/huggingface/transformers/blob/2bd7a27a671fd1d98059124024f580f8f5c0f3b5/src/transformers/models/llama/modeling_llama.py#L92 ) of RoPE even though its present in the official llama GitHub repo. This should work with `max_seq_length` as well. What do you think?

Also the comments say that `freq_cis_real` & `freq_cis_imag` are of shape `(seq_len, dim)` but we share RoPE across heads so this should actually be `(seq_len, head_size)`
