### PR TITLE
Add a link to simple one file pure Python port

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ If your candidate PRs have elements of these it doesn't mean they won't get merg
 - Kotlin
   - [llama2.kt](https://github.com/madroidmaq/llama2.kt) by @[madroidmaq](https://github.com/madroidmaq): a Kotlin port of this project
 - Python
-  - [llama2.py](https://github.com/tairov/llama2.py) by @tairov: a simple one file pure Python port of this project with zero dependencies 
+  - [llama2.py](https://github.com/tairov/llama2.py) by @[tairov](https://github.com/tairov): a simple one file pure Python port of this project with zero dependencies 
 - [llama2.c - Llama 2 Everywhere](https://github.com/trholding/llama2.c) by @[trholding](https://github.com/trholding): Standalone, Bootable & Portable Binary Llama 2
 
 ## unsorted todos

--- a/README.md
+++ b/README.md
@@ -234,10 +234,10 @@ If your candidate PRs have elements of these it doesn't mean they won't get merg
   - [llama2.scala](https://github.com/jrudolph/llama2.scala) by @[jrudolph](https://github.com/jrudolph): a Scala port of this project
 - Java
   - [llama2.java](https://github.com/mukel/llama2.java) by @[mukel](https://github.com/mukel): a Java port of this project
-- Python
-  - [llama2.py](https://github.com/tairov/llama2.py) by @tairov: a simple one file pure Python port of this project with zero dependencies 
 - Kotlin
   - [llama2.kt](https://github.com/madroidmaq/llama2.kt) by @[madroidmaq](https://github.com/madroidmaq): a Kotlin port of this project
+- Python
+  - [llama2.py](https://github.com/tairov/llama2.py) by @tairov: a simple one file pure Python port of this project with zero dependencies 
 - [llama2.c - Llama 2 Everywhere](https://github.com/trholding/llama2.c) by @[trholding](https://github.com/trholding): Standalone, Bootable & Portable Binary Llama 2
 
 ## unsorted todos

--- a/README.md
+++ b/README.md
@@ -234,10 +234,11 @@ If your candidate PRs have elements of these it doesn't mean they won't get merg
   - [llama2.scala](https://github.com/jrudolph/llama2.scala) by @[jrudolph](https://github.com/jrudolph): a Scala port of this project
 - Java
   - [llama2.java](https://github.com/mukel/llama2.java) by @[mukel](https://github.com/mukel): a Java port of this project
+- Python
+  - [llama2.py](https://github.com/tairov/llama2.py) by @tairov: a simple one file pure Python port of this project with zero dependencies 
 - Kotlin
   - [llama2.kt](https://github.com/madroidmaq/llama2.kt) by @[madroidmaq](https://github.com/madroidmaq): a Kotlin port of this project
 - [llama2.c - Llama 2 Everywhere](https://github.com/trholding/llama2.c) by @[trholding](https://github.com/trholding): Standalone, Bootable & Portable Binary Llama 2
-
 
 ## unsorted todos
 


### PR DESCRIPTION
I think it's worthwhile to have a fork that implements Python version of `llama2.c` as a kind of simplest "reference implementation" for further educational purpose for wide audience.

Currently `llama2.c` contains 2`.py` files for training models and and 1 `.c` file for inference. 
There is a gap to have a simple reference implementation of all transformers logic in a simple Python file under 500 lines. While original FB/llama code also implemented in Python, I couldn't say that implementation is simple due to multiple dependencies and optimizations impelemnted.

PS. Performance is awful at the moment `~1 tok./sec`, there is a huge room for improvements. PRs are welcome 😄 
