### PR TITLE
Added conditional include of the OpenMP header.

### DIFF
--- a/run.c
+++ b/run.c
@@ -20,6 +20,11 @@ $ ./run
     #include <unistd.h>
     #include <sys/mman.h>
 #endif
+
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
 // ----------------------------------------------------------------------------
 // Transformer and RunState structs, and related memory management
 


### PR DESCRIPTION
Since the OMP pragmas are used, it seems appropriate to include the openMP header (if the -fopenmp flag is specified).
