### PR TITLE
randomized model for CI workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,17 +3,19 @@ name: Continuous Integration
 on:
   push:
     branches:
-      - master
-    paths: ['.github/workflows/**', '**/Makefile', '**/*.c', '**/*.h']
+      - master, 
+    paths: ['.github/workflows/**', '**/Makefile', '**/*.c', '**/*.h', '**/*.py']
   pull_request:
     types: [opened, synchronize, reopened]
-    paths: ['**/Makefile', '**/*.c', '**/*.h']
+    paths: ['**/Makefile', '**/*.c', '**/*.h', '**/*.py']
+  #for manual trigger
+  workflow_dispatch:  
 
 env:
   BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
 
 jobs:
-  # check basic builds to avoid breaking changes
+  # check basic builds to avoid breaking changes, generate a randomized model and compare the output on different platforms
   ubuntu-focal-make:
     runs-on: ubuntu-20.04
 
@@ -33,13 +35,42 @@ jobs:
         run: |
           make
 
+      - name: Set up Python 10
+        uses: actions/setup-python@v4.7.0
+        with:
+          python-version: '3.10.11'
+          cache: 'pip'
+      
+      - name: Verify Python version
+        run: python --version
+        
+      - run: pip install -r requirements.txt
+      
+      - name: generate ramdomized model
+        run: python train.py --init_from=randomized_model --out_dir=out
+      
+      - name: Sample the randomized model
+        run: |
+          ./run out/randomized_model.bin -t 1.0 -p 0.9 -s 40 -n 256 -i "I feel weired today"  > out/sample.txt
+          cat out/sample.txt
+          
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3.1.2
+        with:
+          name: ubuntu-output
+          path: out/sample.txt          
+
       - name: Build runfast
         id: make_build_runfast
         run: |
           make runfast
 
   macOS-latest-make:
+    needs: ubuntu-focal-make
     runs-on: macos-latest
+    defaults:
+      run:
+        shell: bash
 
     steps:
       - name: Clone
@@ -67,10 +98,49 @@ jobs:
         run: |
           make run CC=clang
 
+      - name: Set up Python 10
+        uses: actions/setup-python@v4.7.0
+        with:
+          python-version: '3.10.11'
+          cache: 'pip'
+  
+      - name: Verify Python version
+        run: python --version
+
+      - name: install python dependencies
+        run: pip install -r requirements.txt
+
+      - name: generate ramdomized model
+        run: python train.py --init_from=randomized_model --out_dir=out      
+
+      - name: Sample the randomized model
+        shell: bash 
+        run: |
+          ./run out/randomized_model.bin -t 1.0 -p 0.9 -s 40 -n 256  -i "I feel weired today" > out/sample.txt          
+          cat out/sample.txt
+
+      - name: Download Ubuntu output
+        uses: actions/download-artifact@v3.0.2
+        with:
+          name: ubuntu-output
+          path: ubuntu-output/
+
+      - name: inspect the two samples
+        shell: bash      
+        run: |
+          cat out/sample.txt
+          cat ubuntu-output/sample.txt
+
+      - name: Compare outputs 
+        shell: bash
+        run: diff -q out/sample.txt ubuntu-output/sample.txt           
+        
   windows-latest-make:
+    needs: ubuntu-focal-make
     runs-on: windows-latest
 
     strategy:
+      fail-fast: false
       matrix:
         arch:
           - amd64
@@ -95,7 +165,55 @@ jobs:
         run: |
           .\build_msvc.bat
 
+      - name: Set up Python 10
+        if: matrix.arch != 'amd64_arm64'
+        uses: actions/setup-python@v4.7.0
+        with:
+          python-version: '3.10.11'
+          cache: 'pip'
+        
+      - name: Verify Python version
+        if: matrix.arch != 'amd64_arm64'
+        run: python --version
+
+      - name: install python dependencies 
+        if: matrix.arch != 'amd64_arm64'
+        run: pip install -r requirements.txt
+        
+      - name: generate ramdomized model
+        if: matrix.arch != 'amd64_arm64'
+        run: python train.py --init_from=randomized_model --out_dir=out
+
+      - name: Sample the randomized model
+        if: matrix.arch != 'amd64_arm64'
+        run: |
+          .\run.exe out\randomized_model.bin -t 1.0 -p 0.9 -s 40 -n 256  -i "I feel weired today" | Out-File -FilePath out\sample.txt          
+
+      - name: Download Ubuntu output
+        if: matrix.arch != 'amd64_arm64'
+        uses: actions/download-artifact@v3.0.2
+        with:
+          name: ubuntu-output
+          path: ubuntu-output/    
+      
+      - name: inspect the two samples
+        if: matrix.arch != 'amd64_arm64'
+        run: |
+          Get-Content out\sample.txt
+          Get-Content ubuntu-output\sample.txt
+          
+      - name: Compare outputs
+        if: matrix.arch != 'amd64_arm64'
+        shell: powershell
+        run: |
+          $diff = Compare-Object -ReferenceObject (Get-Content -Path out/sample.txt -Encoding UTF8) -DifferenceObject (Get-Content -Path ubuntu-output/sample.txt -Encoding UTF8)
+          if ($diff) {
+            Write-Output "Files are not identical."
+            Write-Output $diff
+              exit 1
+          }
   windows-latest-mingw:
+    needs: ubuntu-focal-make    
     runs-on: windows-latest
 
     defaults:
@@ -122,3 +240,48 @@ jobs:
         id: build_mingw
         run: |
           make win64
+        
+      - name: Set up Python 10        
+        uses: actions/setup-python@v4.7.0
+        with:
+          python-version: '3.10.11'
+          cache: 'pip'
+        
+      - name: Verify Python version
+        shell: powershell
+        run: python --version
+
+      - name: install python dependencies 
+        shell: powershell
+        run: pip install -r requirements.txt
+        
+      - name: generate ramdomized model
+        shell: powershell
+        run: python train.py --init_from=randomized_model --out_dir=out
+
+      - name: Sample the randomized model
+        shell: powershell
+        run: |
+          .\run.exe out\randomized_model.bin -t 1.0 -p 0.9 -s 40 -n 256 -i "I feel weired today" | Out-File -FilePath out\sample.txt          
+                  
+      - name: Download Ubuntu output        
+        uses: actions/download-artifact@v3.0.2
+        with:
+          name: ubuntu-output
+          path: ubuntu-output/    
+      
+      - name: inspect the two samples
+        shell: powershell
+        run: |
+          Get-Content out\sample.txt
+          Get-Content ubuntu-output\sample.txt
+          
+      - name: Compare outputs
+        shell: powershell
+        run: |
+          $diff = Compare-Object -ReferenceObject (Get-Content -Path out/sample.txt -Encoding UTF8) -DifferenceObject (Get-Content -Path ubuntu-output/sample.txt -Encoding UTF8)
+          if ($diff) {
+            Write-Output "Files are not identical."
+            Write-Output $diff
+              exit 1
+          }  

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -187,7 +187,7 @@ jobs:
       - name: Sample the randomized model
         if: matrix.arch != 'amd64_arm64'
         run: |
-          .\run.exe out\randomized_model.bin -t 1.0 -p 0.9 -s 40 -n 256  -i "I feel weired today" | Out-File -FilePath out\sample.txt          
+          .\run.exe out\randomized_model.bin -t 1.0 -p 0.9 -s 40 -n 256  -i "I feel weired today" | Out-File -FilePath out\sample.txt -Encoding UTF8         
 
       - name: Download Ubuntu output
         if: matrix.arch != 'amd64_arm64'
@@ -199,8 +199,8 @@ jobs:
       - name: inspect the two samples
         if: matrix.arch != 'amd64_arm64'
         run: |
-          Get-Content out\sample.txt
-          Get-Content ubuntu-output\sample.txt
+          Get-Content -Path out\sample.txt -Encoding UTF8
+          Get-Content -Path ubuntu-output\sample.txt -Encoding UTF8
           
       - name: Compare outputs
         if: matrix.arch != 'amd64_arm64'
@@ -262,7 +262,7 @@ jobs:
       - name: Sample the randomized model
         shell: powershell
         run: |
-          .\run.exe out\randomized_model.bin -t 1.0 -p 0.9 -s 40 -n 256 -i "I feel weired today" | Out-File -FilePath out\sample.txt          
+          .\run.exe out\randomized_model.bin -t 1.0 -p 0.9 -s 40 -n 256 -i "I feel weired today" | Out-File -FilePath out\sample.txt -Encoding UTF8
                   
       - name: Download Ubuntu output        
         uses: actions/download-artifact@v3.0.2
@@ -273,8 +273,8 @@ jobs:
       - name: inspect the two samples
         shell: powershell
         run: |
-          Get-Content out\sample.txt
-          Get-Content ubuntu-output\sample.txt
+          Get-Content -Path out\sample.txt -Encoding UTF8
+          Get-Content -Path ubuntu-output\sample.txt -Encoding UTF8
           
       - name: Compare outputs
         shell: powershell

--- a/train.py
+++ b/train.py
@@ -66,7 +66,7 @@ grad_clip = 1.0  # clip gradients at this value, or disable if == 0.0
 decay_lr = True  # whether to decay the learning rate
 warmup_iters = 1000  # how many steps to warm up for
 # system
-device = "cuda"  # examples: 'cpu', 'cuda', 'cuda:0', 'cuda:1' etc., or try 'mps' on macbooks
+device = "cpu"  # examples: 'cpu', 'cuda', 'cuda:0', 'cuda:1' etc., or try 'mps' on macbooks
 dtype = "bfloat16"  # float32|bfloat16|float16
 compile = True  # use PyTorch 2.0 to compile the model to be faster
 # -----------------------------------------------------------------------------
@@ -175,6 +175,20 @@ elif init_from == "resume":
     model.load_state_dict(state_dict)
     iter_num = checkpoint["iter_num"]
     best_val_loss = checkpoint["best_val_loss"]
+elif init_from == "randomized_model":
+    #init a model with random weights for CI test
+    gptconf = ModelArgs(**model_args)
+    model = Transformer(gptconf)
+    state_dict = model.state_dict()    
+    state_dict = model.state_dict()    
+    torch.manual_seed(40)    
+    #radnomize the weights
+    for name in state_dict:
+        state_dict[name] = torch.rand_like(state_dict[name])
+    # Load the randomized state_dict back into the model
+    model.load_state_dict(state_dict)        
+    model.export(os.path.join(out_dir, "randomized_model.bin"))
+    exit(0)
 model.to(device)
 
 # initialize a GradScaler. If enabled=False scaler is a no-op


### PR DESCRIPTION
Augments `train.py` to generate a randomized model. And extends the CI workflow to generate and sample the randomized model. The sample of Ubuntu serves as the reference and other samples are checked against it, as suggested by @karpathy in #175.

arm64 (windows) is excluded, because the binaries from the `amd64_arm64` cross-compilation cannot be run on the `amd64` runner. Selfhosting or QEMU does it?

Interestingly the the output tokens do NOT match for windows and ubuntu! This is the comparison:
`ubuntu` vs `amd64` and `amd64-x86` and `mingw`
![image](https://github.com/karpathy/llama2.c/assets/20722797/020e0072-90ac-4e1b-90da-8263b5f0a50f)

