### PR TITLE
Only C complient optimisation for windows and mingw

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ runomp: run.c
 
 .PHONY: win64
 win64:
-	x86_64-w64-mingw32-gcc -Ofast -D_WIN32 -o run.exe -I. run.c win.c
+	x86_64-w64-mingw32-gcc -O3 -D_WIN32 -o run.exe -I. run.c win.c
 
 # compiles with gnu99 standard flags for amazon linux, coreos, etc. compatibility
 .PHONY: rungnu

--- a/build_msvc.bat
+++ b/build_msvc.bat
@@ -1,1 +1,2 @@
-cl.exe /fp:fast /Ox /openmp /I. run.c win.c 
+cl.exe /Ob2 /Oi /Ot /Oy  /openmp /I. run.c win.c 
+


### PR DESCRIPTION
The randomized model of RP #261 makes (slightly) different tokens on ubuntu and macOS on one side and Windows and mingw on the other side. 
This is because the builds use non C complaint optimisation. This RP fixes this issue, so the random model has identical output on all systems.
Notice that ubuntu and macOS builds still use non C complient optimisation, which is safer to fix.