### PR TITLE
Update README.md for a new rust port.

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ If your candidate PRs have elements of these it doesn't mean they won't get merg
   - [llama2.rs](https://github.com/gaxler/llama2.rs) by @[gaxler](https://github.com/gaxler): a Rust port of this project
   - [llama2.rs](https://github.com/leo-du/llama2.rs) by @[leo-du](https://github.com/leo-du): A Rust port of this project
   - [llama2-rs](https://github.com/danielgrittner/llama2-rs) by @[danielgrittner](https://github.com/danielgrittner): a Rust port of this project
+  - [llama2.rs](https://github.com/lintian06/llama2.rs) by @[lintian06](https://github.com/lintian06): A Rust port of this project
 - Go
   - [go-llama2](https://github.com/tmc/go-llama2) by @[tmc](https://github.com/tmc): a Go port of this project
   - [llama2.go](https://github.com/nikolaydubina/llama2.go) by @[nikolaydubina](https://github.com/nikolaydubina): a Go port of this project


### PR DESCRIPTION
Update README.md for new rust port [llama2.rs](https://github.com/lintian06/llama2.rs).

Highlights:
- Similar to llama2.c with openmp, llama2.rs also utilizes model parallelization. (Performance gain: #tokens/s: 27.585 -> 40.228 on `stories110M.bin`)
- Utilize memory mapping to runtime memory (480MB -> 59MB, save up to 88%).

See [performance comparison](https://github.com/lintian06/llama2.rs/tree/master#performance-comparison) section in the repo for more details.



