### PR TITLE
Update readme to introduce llama2.c-zh

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ If your candidate PRs have elements of these it doesn't mean they won't get merg
 - WebAssembly
   - [icpp-llm](https://github.com/icppWorld/icpp-llm): LLMs for the Internet Computer
 - [llama2.c - Llama 2 Everywhere](https://github.com/trholding/llama2.c) by @[trholding](https://github.com/trholding): Standalone, Bootable & Portable Binary Llama 2
+- [llama2.c-zh - Bilingual Chinese and English](https://github.com/chenyangMl/llama2.c-zh) by @[chenyangMl](https://github.com/chenyangMl): Expand tokenizer to support training and inferencing in both Chinese and English
 
 ## unsorted todos
 

--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ If your candidate PRs have elements of these it doesn't mean they won't get merg
 - WebAssembly
   - [icpp-llm](https://github.com/icppWorld/icpp-llm): LLMs for the Internet Computer
 - [llama2.c - Llama 2 Everywhere](https://github.com/trholding/llama2.c) by @[trholding](https://github.com/trholding): Standalone, Bootable & Portable Binary Llama 2
-- [llama2.c-zh - Bilingual Chinese and English](https://github.com/chenyangMl/llama2.c-zh) by @[chenyangMl](https://github.com/chenyangMl): Expand tokenizer to support training and inferencing in both Chinese and English
+- [llama2.c-zh - Bilingual Chinese and English](https://github.com/chenyangMl/llama2.c-zh) by @[chenyangMl](https://github.com/chenyangMl): Expand tokenizer to support training and inference in both Chinese and English
 
 ## unsorted todos
 


### PR DESCRIPTION
[llama2.c-zh](https://github.com/chenyangMl/llama2.c-zh/blob/main/assets/readme_en.md) is built on [llama2.c](https://github.com/karpathy/llama2.c), and expand tokenizer to support training and inference in both Chinese and English.   #158 