### PR TITLE
CI pytest for macOS and windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,6 +68,21 @@ jobs:
         run: |
           brew update
 
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.10"
+
+      - name: Pip setup
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+
+      - name: Build clang
+        id: make_build_clang
+        run: |
+          make run CC=clang
+
       - name: Build
         id: make_build
         run: |
@@ -77,16 +92,18 @@ jobs:
         id: make_build_runfast
         run: |
           make runfast
+      
+      - name: Test with pytest
+        run: pytest
+  
 
-      - name: Build clang
-        id: make_build_clang
-        run: |
-          make run CC=clang
+
 
   windows-latest-make:
     runs-on: windows-latest
 
     strategy:
+      fail-fast: false  #necessary, otherwise the matrix breaks 
       matrix:
         arch:
           - amd64
@@ -106,10 +123,29 @@ jobs:
         with:
           arch: ${{ matrix.arch }}
 
+      - name: Set up Python 3.10
+        if: matrix.arch != 'amd64_arm64'
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.10"
+  
+      - name: Pip setup
+        if: matrix.arch != 'amd64_arm64'
+        run: |
+          python -m pip install --upgrade pip
+          if (Test-Path requirements.txt) {
+            pip install -r requirements.txt
+          }
+
       - name: Build ${{ matrix.arch }}
         id: build_msvc
         run: |
           .\build_msvc.bat
+
+      #cross-comiled, cannot be run on host
+      - name: Test with pytest
+        if: matrix.arch != 'amd64_arm64'  
+        run: pytest        
 
   windows-latest-mingw:
     runs-on: windows-latest
@@ -135,6 +171,26 @@ jobs:
           install: mingw-w64-${{matrix.env}}-gcc make
 
       - name: Build ${{ matrix.sys }} ${{ matrix.env }}
-        id: build_mingw
+        id: build_mingw        
         run: |
           make win64
+      
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.10"
+    
+      - name: Pip setup
+        shell: powershell
+        run: |
+          python -m pip install --upgrade pip
+          if (Test-Path requirements.txt) {
+            pip install -r requirements.txt
+          }
+  
+      - name: Test with pytest
+        shell: powershell
+        run: pytest      
+
+
+    

--- a/test_all.py
+++ b/test_all.py
@@ -30,7 +30,7 @@ def attempt_download_files():
     root_url = "https://huggingface.co/karpathy/tinyllamas/resolve/main/stories260K"
     need = ["stories260K.bin", "stories260K.pt", "tok512.bin", "tok512.model"]
     for file in need:
-        url = os.path.join(root_url, file)
+        url = root_url + '/' + file   #os.path.join inserts \\ on windows 
         filename = os.path.join(test_ckpt_dir, file)
         if not os.path.exists(filename):
             download_file(url, filename)
@@ -46,13 +46,17 @@ def test_runc():
 
     model_path = os.path.join(test_ckpt_dir, "stories260K.bin")
     tokenizer_path = os.path.join(test_ckpt_dir, "tok512.bin")
-    command = ["./run", model_path, "-z", tokenizer_path, "-t", "0.0", "-n", "200"]
-    proc = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-
-    stdout, stderr = proc.communicate()
-
+    command = ["./run", model_path, "-z", tokenizer_path, "-t", "0.0", "-n", "200"]    
+    with open('err.txt', mode='wb') as fe:  
+        with open('stdout.txt', mode='wb') as fo:
+            proc = subprocess.Popen(command, stdout=fo, stderr=fe)  #pipe in windows terminal does funny things like replacing \n with \r\n
+            proc.wait()
+                
+    with open('stdout.txt', mode='r') as f:
+        stdout = f.read()
     # strip the very last \n that is added by run.c for aesthetic reasons
-    stdout = stdout[:-1]
+    stdout = stdout[:-1].encode('ascii')
+    
     assert stdout == expected_stdout
 
 def test_python():
@@ -83,3 +87,5 @@ def test_python():
     text = text.encode('ascii') # turn into bytes
 
     assert text == expected_stdout
+
+test_runc()


### PR DESCRIPTION
extends CI to run the pytest (#285) also for macOS and windows (except amd64_arm64).

prev. PR: #268 
see also: #265