### PR TITLE
Replace mmap with aligned weight loading

### DIFF
--- a/run.c
+++ b/run.c
@@ -617,9 +617,9 @@ int main(int argc, char *argv[]) {
         fseek(file, sizeof(Config), SEEK_SET); // rewind to after the Config header
         size_t weights_size = file_size - sizeof(Config);
 
-        // allocate memory for the weights, page aligned for best performance
-        data = (float*) aligned_alloc(sysconf(_SC_PAGESIZE), weights_size);
-        if (!data) { fprintf(stderr, "aligned_alloc failed!\n"); return 1; }
+        // allocate memory for the weights
+        data = (float*) malloc(weights_size);
+        if (!data) { fprintf(stderr, "malloc failed!\n"); return 1; }
 
         // Read the weights into the allocated memory
         if (fread(data, 1, weights_size, file) != weights_size) {


### PR DESCRIPTION
After our discussion on cache alignment in #94, I was curious to know what the performance boost would be of getting the weights properly aligned. The easiest way to do this was switch from mmap to manually loading the weights. This allows us to skip changing the file format because we can first read in the config, then the rest of the weights on whatever alignment we like. Implementing this [in my Zig fork](https://github.com/cgbur/llama2.zig/commit/23c0711308cfe52971834b3c5716e497e7d6dc3d) was a small speed win, but an even bigger one here. I chose page alignment for two reasons. 1) it was the alignment of the previous mmap data 2) it will not share a page with any other data and forevermore have the perfect alignment. 

EDIT: I have reverted the page part as I could not find a good cross platform way that did not involve some ugliness. The results for the three are in the below table, see the comments for an image of the comparison

| Metric         | Mmapped  | Aligned | Normal Aligned | Aligned vs Mmapped (%) | Normal Aligned vs Mmapped (%) |
|----------------|----------|---------|----------------|------------------------|-------------------------------|
| Average Speed  | 496.50   | 623.88  | 596.86         | 25.66%                 | 20.21%                         |
| Max Speed      | 513.95   | 646.20  | 626.06         | 25.73%                 | 21.81%                         |


Here's the comparison for the 15m parameter model:

| Metric        | Mmapped | Aligned | Percent Difference |
| ------------- | ------- | ------- | ------------------ |
| Average Speed | 496.50  | 623.88  | 25.66%             |
| Max Speed     | 513.95  | 646.20  | 25.73%             |

Here's the comparison for the 42m parameter model:

| Metric        | Mmapped | Aligned | Percent Difference |
| ------------- | ------- | ------- | ------------------ |
| Average Speed | 176.39  | 232.95  | 32.07%             |
| Max Speed     | 179.44  | 242.05  | 34.89%             |

As you can see the speedup is quite significant for a small code change. I would be curious to see the results tested on an macbook as well as on larger (7b) parameter models. 

I've also noticed this speedup mostly happens on the runfast with and without `march=native`. If you wish to reproduce my results, my make command is listed below.

![image](https://github.com/karpathy/llama2.c/assets/9002722/00b71537-3f89-4cc6-aa36-8320d8383660)
![image](https://github.com/karpathy/llama2.c/assets/9002722/ce4c977d-d9cc-4a50-a64d-991ac1c9264c)

All benchmarks ran with the following make configuration on an AMD 5900x

```make
.PHONY: runfast
runfast: run.c
	$(CC) -Ofast -o run run.c -lm -march=native

```
Fish to benchmark
```fish
 while true; ./run stories42M.bin -t 0 | rg "tok" ; end
```