### PR TITLE
Jupter Notebook: Add run Meta's Llama 2 models

### DIFF
--- a/run.ipynb
+++ b/run.ipynb
@@ -89,6 +89,27 @@
         "cmd = f'./run {model_file} -t {temperature} -p {top_p} -n {max_token} -i \"{prompt}\"'\n",
         "!{cmd}"
       ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "#@title Run Meta's Llama 2 models\n",
+        "\n",
+        "#@markdown input your huggingface [access token](https://huggingface.co/settings/tokens) to download Meta's Llama 2 models.\n",
+        "\n",
+        "from huggingface_hub import snapshot_download\n",
+        "\n",
+        "token = \"replace your huggingface access token\" #@param {type:\"string\"}\n",
+        "path = snapshot_download(repo_id=\"meta-llama/Llama-2-7b\",cache_dir=\"Llama-2-7b\", use_auth_token=token)\n",
+        "\n",
+        "!python export_meta_llama_bin.py $path llama2_7b.bin\n",
+        "\n",
+        "print(\"./run llama2_7b.bin\\n\")\n",
+        "!./run llama2_7b.bin"
+      ]
     }
   ],
   "metadata": {


### PR DESCRIPTION

## Jupter show:
<img width="671" alt="image" src="https://github.com/karpathy/llama2.c/assets/6247142/770f43b3-2c96-41a0-ac78-711667bdd71a">

## output:
<img width="836" alt="image" src="https://github.com/karpathy/llama2.c/assets/6247142/55b6206c-1353-499f-a201-895ab9cf141d">
