### PR TITLE
const cuttoff in sample_topp 

### DIFF
--- a/run.c
+++ b/run.c
@@ -520,7 +520,7 @@ int sample_topp(float* probabilities, int n, float topp, ProbIndex* probindex) {
     // quicksort indices in descending order of probabilities
     // values smaller than (1 - topp) / (n - 1) cannot be part of the result
     // so for efficiency we crop these out as candidates before sorting
-    const float cutoff = (1.0f - topp) / (n - 1);
+    const float cutoff = 0.001; //a practical lowerbound for the probabilities that get sampled
     for (int i = 0; i < n; i++) {
         if (probabilities[i] >= cutoff) {
             probindex[n0].index = i;


### PR DESCRIPTION
Refs #246 #276

This works because, practically, the probabilities that get sampled are more than 0.001. Therefore smaller values can be safely filtered (the cuteoff used in #276 evaluates to ~0.00003).
#276 reduces the sizes of the to be sorted array from 32000 to an average of 172, this PR further reduces it to 12.

There are other possible ways to further optimize the code, but as topp is no more a bottleneck, it doesn't affect the token/s much, thus I don't know if it would be interesting.