### PR TITLE
YARP - Yet Another Rust Port in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ If your candidate PRs have elements of these it doesn't mean they won't get merg
   - [llama2.rs](https://github.com/leo-du/llama2.rs) by @[leo-du](https://github.com/leo-du): A Rust port of this project
   - [llama2-rs](https://github.com/danielgrittner/llama2-rs) by @[danielgrittner](https://github.com/danielgrittner): a Rust port of this project
   - [llama2.rs](https://github.com/lintian06/llama2.rs) by @[lintian06](https://github.com/lintian06): A Rust port of this project
+  - [pecca.rs](https://github.com/rahoua/pecca-rs) by @[rahoua](https://github.com/rahoua): A Rust port leveraging [ndarray](https://github.com/rust-ndarray/ndarray), supports BLAS.
 - Go
   - [go-llama2](https://github.com/tmc/go-llama2) by @[tmc](https://github.com/tmc): a Go port of this project
   - [llama2.go](https://github.com/nikolaydubina/llama2.go) by @[nikolaydubina](https://github.com/nikolaydubina): a Go port of this project


### PR DESCRIPTION
But hey, at least [pecca-rs](https://github.com/rahoua/pecca-rs) is a little different as it uses Rust [ndarray](https://github.com/rust-ndarray/ndarray). So matrices have (almost) all the right dimensions and a good amount of slicing is made safer and more succinct.