### PR TITLE
Give better error message in Tinystories data loader

### DIFF
--- a/tinystories.py
+++ b/tinystories.py
@@ -196,6 +196,7 @@ class PretokDataset(torch.utils.data.IterableDataset):
             shard_filenames = sorted(glob.glob(os.path.join(bin_dir, "*.bin")))
         # train/test split. let's use only shard 0 for test split, rest train
         shard_filenames = shard_filenames[1:] if self.split == "train" else shard_filenames[:1]
+        assert len(shard_filenames)>0, f"No bin files found in {bin_dir}"
         while True:
             rng.shuffle(shard_filenames)
             for shard in shard_filenames:


### PR DESCRIPTION
There are few open issues of people getting stuck running `train.py` because `tinystories.py` data loader will be stuck in an infinite loop if there are no .bin files in the data directory. Have added an assert statement so that there is a more informative error message rather than training just being stuck.

Relevant issues
https://github.com/karpathy/llama2.c/issues/296
https://github.com/karpathy/llama2.c/issues/311 