### PR TITLE
Added huggingface model loader/importer to export.py

### DIFF
--- a/export.py
+++ b/export.py
@@ -303,11 +303,15 @@ def load_hf_model(model_path):
     model.tok_embeddings.weight = nn.Parameter(hf_dict['model.embed_tokens.weight'])
     model.norm.weight = nn.Parameter(hf_dict['model.norm.weight'])
 
+    # huggingface permutes WQ and WK, this function reverses it
+    def permute_reverse(w, n_heads=config.n_heads, dim1=config.dim, dim2=config.dim):
+        return w.view(n_heads, 2, dim1 // n_heads // 2, dim2).transpose(1, 2).reshape(dim1, dim2)
+
     for layer in model.layers:
         i = layer.layer_id
         layer.attention_norm.weight = nn.Parameter(hf_dict[f'model.layers.{i}.input_layernorm.weight'])
-        layer.attention.wq.weight = nn.Parameter(hf_dict[f'model.layers.{i}.self_attn.q_proj.weight'])
-        layer.attention.wk.weight = nn.Parameter(hf_dict[f'model.layers.{i}.self_attn.k_proj.weight'])
+        layer.attention.wq.weight = nn.Parameter(permute_reverse(hf_dict[f'model.layers.{i}.self_attn.q_proj.weight']))
+        layer.attention.wk.weight = nn.Parameter(permute_reverse(hf_dict[f'model.layers.{i}.self_attn.k_proj.weight']))
         layer.attention.wv.weight = nn.Parameter(hf_dict[f'model.layers.{i}.self_attn.v_proj.weight'])
         layer.attention.wo.weight = nn.Parameter(hf_dict[f'model.layers.{i}.self_attn.o_proj.weight'])
         layer.ffn_norm.weight = nn.Parameter(hf_dict[f'model.layers.{i}.post_attention_layernorm.weight'])

--- a/export.py
+++ b/export.py
@@ -280,7 +280,12 @@ def load_checkpoint(checkpoint):
 
 def load_hf_model(model_path):
 
-    from transformers import AutoModelForCausalLM
+    try:
+        from transformers import AutoModelForCausalLM
+    except ImportError:
+        print("Error: transformers package is required to load huggingface models")
+        print("Please run `pip install transformers` to install it")
+        return None
 
     # load HF model
     hf_model = AutoModelForCausalLM.from_pretrained(model_path)
@@ -356,6 +361,9 @@ if __name__ == "__main__":
         model = load_hf_model(args.hf)
     else:
         parser.error("Input model missing: --checkpoint or --hf is required")
+
+    if model is None:
+        parser.error("Can't load input model!")
 
     # export
     model_export(model, args.filepath, args.version)

--- a/model.py
+++ b/model.py
@@ -17,6 +17,7 @@ class ModelArgs:
     n_heads: int = 32
     n_kv_heads: Optional[int] = None
     vocab_size: int = 32000
+    hidden_dim: int = (4 * 4096)
     multiple_of: int = 256  # MLP hidden layer size will be multiple of
     norm_eps: float = 1e-5
     max_seq_len: int = 2048
@@ -186,7 +187,7 @@ class TransformerBlock(nn.Module):
         self.attention = Attention(args)
         self.feed_forward = FeedForward(
             dim=args.dim,
-            hidden_dim=4 * args.dim,
+            hidden_dim=args.hidden_dim,
             multiple_of=args.multiple_of,
             dropout=args.dropout,
         )

--- a/model.py
+++ b/model.py
@@ -17,7 +17,7 @@ class ModelArgs:
     n_heads: int = 32
     n_kv_heads: Optional[int] = None
     vocab_size: int = 32000
-    hidden_dim: int = (4 * 4096)
+    hidden_dim: Optional[int] = None
     multiple_of: int = 256  # MLP hidden layer size will be multiple of
     norm_eps: float = 1e-5
     max_seq_len: int = 2048
@@ -167,8 +167,10 @@ class Attention(nn.Module):
 class FeedForward(nn.Module):
     def __init__(self, dim: int, hidden_dim: int, multiple_of: int, dropout: float):
         super().__init__()
-        hidden_dim = int(2 * hidden_dim / 3)
-        hidden_dim = multiple_of * ((hidden_dim + multiple_of - 1) // multiple_of)
+        if hidden_dim is None:
+            hidden_dim = 4 * dim
+            hidden_dim = int(2 * hidden_dim / 3)
+            hidden_dim = multiple_of * ((hidden_dim + multiple_of - 1) // multiple_of)
         self.w1 = nn.Linear(dim, hidden_dim, bias=False)
         self.w2 = nn.Linear(hidden_dim, dim, bias=False)
         self.w3 = nn.Linear(dim, hidden_dim, bias=False)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,3 @@ sentencepiece==0.1.99
 torch==2.0.1
 tqdm==4.64.1
 wandb==0.15.5
-transformers==4.31.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ sentencepiece==0.1.99
 torch==2.0.1
 tqdm==4.64.1
 wandb==0.15.5
+transformers==4.31.0


### PR DESCRIPTION
Summary:
 * Added `load_hf_model()` function to export.py
 * Correctly set `shared_classifier` flag and write classifier weights if exists, in all export functions
 * Added `hidden_dim` to `ModelArgs`
 * Added `--hf` CLI argument to load HF model

Tests:
 * Legacy export with Llama-2-7b-chat-hf model - OK
 * model.py inference with generate() - OK

Fixes:
 * https://github.com/karpathy/llama2.c/issues/314
 * WQ / WK permutation bug reported in comments: https://github.com/karpathy/llama2.c/pull/286#issuecomment-1679066644