### PR TITLE
Remove unneeded check of free(NULL)

### DIFF
--- a/run.c
+++ b/run.c
@@ -799,7 +799,7 @@ int main(int argc, char *argv[]) {
     }
 
     // memory and file handles cleanup
-    if (prompt_tokens != NULL) { free(prompt_tokens); }
+    free(prompt_tokens);
     free_sampler(&sampler);
     free_tokenizer(&tokenizer);
     free_transformer(&transformer);


### PR DESCRIPTION
Passing `NULL` to `free()` is totally allowed