### PR TITLE
make transformer a global variable

### DIFF
--- a/run.c
+++ b/run.c
@@ -688,15 +688,13 @@ int sample(Sampler* sampler) {
         for (int q=0; q<transformer.config.vocab_size; q++) { transformer.state.logits[q] /= sampler->temperature; }
         // apply softmax to the logits to get the probabilities for next token
         softmax(transformer.state.logits, transformer.config.vocab_size);
-        // flip a (float) coin (this is our source of entropy for sampling)
-        float coin = random_f32(&sampler->rng_state);
         // we sample from this distribution to get the next token
         if (sampler->topp <= 0 || sampler->topp >= 1) {
             // simply sample from the predicted probability distribution
-            next = sample_mult(logits, coin);
+            next = sample_mult(sampler);
        } else {
             // top-p (nucleus) sampling, clamping the least likely tokens to zero
-            next = sample_topp(sampler, coin);
+            next = sample_topp(sampler);
         }
     }
     return next;

--- a/run.c
+++ b/run.c
@@ -698,7 +698,7 @@ long time_in_ms() {
 // ----------------------------------------------------------------------------
 // generation loop
 
-void generate(Transformer *transformer, Tokenizer *tokenizer, Sampler *sampler, char *prompt, int steps) {
+void generate(Tokenizer *tokenizer, Sampler *sampler, char *prompt, int steps) {
     // encode the (string) prompt into tokens sequence, if any is given
     int *prompt_tokens = NULL; // the sequence of prompt tokens
     int num_prompt_tokens = 0; // the total number of prompt tokens
@@ -715,7 +715,7 @@ void generate(Transformer *transformer, Tokenizer *tokenizer, Sampler *sampler, 
     while (pos < steps) {
 
         // forward the transformer to get logits for the next token
-        forward(transformer, token, pos);
+        forward(&transformer, token, pos);
 
         // advance the state state machine
         if (pos < num_prompt_tokens) {
@@ -812,7 +812,7 @@ int main(int argc, char *argv[]) {
     Sampler sampler = {.temperature = temperature, .topp = topp, .rng_state = rng_seed};
 
     // run!
-    generate(&transformer, &tokenizer, &sampler, prompt, steps);
+    generate(&tokenizer, &sampler, prompt, steps);
 
     // memory and file handles cleanup
     free_tokenizer(&tokenizer);

--- a/run.c
+++ b/run.c
@@ -199,10 +199,8 @@ void rmsnorm(float* o, float* x, float* weight, int size) {
     }
 }
 
-void softmax() {
+void softmax(float* x, uint16_t size) {
     // find max value (for numerical stability)
-    const uint16_t size = transformer.config.vocab_size;
-    float *x = transformer.state.logits;
 
     float max_val = x[0];
     for (int i = 1; i < size; i++) {
@@ -679,15 +677,15 @@ void free_sampler(Sampler* sampler) {
 uint16_t sample(Sampler* sampler) {
     // sample the token given the logits and some hyperparameters
     uint16_t next;
-    const uint16_t vocab_size = transformer.config.vocab_size;
+    // const uint16_t vocab_size = transformer.config.vocab_size;
     if (sampler->temperature == 0.0f) {
         // greedy argmax sampling: take the token with the highest probability
         next = sample_argmax();
     } else {
         // apply the temperature to the logits
-        for (int q=0; q<vocab_size; q++) { transformer.state.logits[q] /= sampler->temperature; }
+        for (int q=0; q<transformer.config.vocab_size; q++) { transformer.state.logits[q] /= sampler->temperature; }
         // apply softmax to the logits to get the probabilities for next token
-        softmax();
+        softmax(transformer.state.logits, transformer.config.vocab_size);
         // we sample from this distribution to get the next token
         if (sampler->topp <= 0 || sampler->topp >= 1) {
             // simply sample from the predicted probability distribution


### PR DESCRIPTION
This simplifies the code, specially struct `ProbIndex` is removed.

A global `transfomer` is safe, as it is the only instance of its type, and like OOP, makes its data accessible to relevant functions. 

Other changes:
`sample_topp()` allocates its array as a local var (removing `build_sampler()` and `free_sampler()`)
using `stdint` types (still not complete, see #215)

Next Step:
Making tokenizer a global var, for same reasons.