### PR TITLE
Clearer WandB log step

### DIFF
--- a/train.py
+++ b/train.py
@@ -271,7 +271,7 @@ while True:
                         "loss/val": losses["val"],
                         "lr": lr,
                         "mfu": running_mfu * 100,  # convert to percentage
-                    }
+                    }, step = iter_num
                 )
             except Exception as e:
                 print(f"logging to wandb failed: {e}")


### PR DESCRIPTION
**Problem**: We only log to WandB every `eval_interval (default=2000)` steps, but WandB by default registers this as 1 single step. This creates confusing graphs where a TinyStories-15M pretraining run only takes "50 steps" on WandB.

 **Solution**: Redefine WandB's [`step`](https://docs.wandb.ai/ref/python/log#:~:text=commit%3DTrue.-,step,-(integer%2C%20optional)%20The) as our `iter_num`.