### PR TITLE
Add llama2.c-web to the list of projects in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,8 @@ If your candidate PRs have elements of these it doesn't mean they won't get merg
   - [llama2.cs](https://github.com/trrahul/llama2.cs) by @[trrahul](https://github.com/trrahul): a C# port of this project
 - Dart
   - [llama2.dart](https://github.com/yiminghan/llama2.dart) by @[yiminghan](https://github.com/yiminghan/llama2.dart): one-file dart port of this project, works with Flutter!
+- Web
+  - [llama2c-web](https://github.com/dmarcos/llama2.c-web) by @[dmarcos](https://github.com/dmarcos): Super simple way to build unmodified llama2.c to WASM and run it in the browser. [Demo](https://diegomarcos.com/llama2.c-web/)
 - WebAssembly
   - [icpp-llm](https://github.com/icppWorld/icpp-llm): LLMs for the Internet Computer
 - [llama2.c - Llama 2 Everywhere](https://github.com/trholding/llama2.c) by @[trholding](https://github.com/trholding): Standalone, Bootable & Portable Binary Llama 2


### PR DESCRIPTION
I created a simple repo that builds llama2.c with no alterations to WASM and runs it in the Browser.

This is a [demo](https://diegomarcos.com/llama2.c-web/).

- No build system. Just a bash script.
- No Emscripten. 
- [llama2.c repo](https://github.com/karpathy/llama2.c) is a git submodule and code builds without modifications.
- It runs llama2.c in a Web Worker to not block the main thread.
- On my M1 MacBook Air native inference runs at ~100 tokens/s and ~80 tokens/s in the Browser. 20% overhead but haven't spend anytime yet optimizing. Suggestions more than welcome.

I'm also looking for small models that do interesting things and build more Web based demos. Any suggestions super appreciated!

This is a lot of fun. Keep up the great work!