### PR TITLE
Setting an encoding for tiny_file tokenizer file.

### DIFF
--- a/tinystories.py
+++ b/tinystories.py
@@ -88,7 +88,7 @@ def train_vocab(vocab_size):
     shard_filenames = sorted(glob.glob(os.path.join(data_dir, "*.json")))
 
     print(f"Writing temporary file {tiny_file} with {num_shards} shards...")
-    with open(tiny_file, "w") as of:
+    with open(tiny_file, "w", encoding="utf-8") as of:
         for shard in tqdm(shard_filenames[:num_shards]):
             with open(shard, "r") as f:
                 data = json.load(f)


### PR DESCRIPTION
Setting UTF encoding, otherwise Windows breaks with UnicodeEncodeErrorr: 'charmap' codec can't encode character '\u200b' in position 971: character maps to <undefined>