### PR TITLE
int8 refactor

### DIFF
--- a/export.py
+++ b/export.py
@@ -194,7 +194,7 @@ def version2_export(model, filepath, group_size=64):
         group_size //= 2
         print(f"BACKOFF: reducing group size to {group_size} to fit hidden_dim")
     weights = [
-        *[row for row in model.tok_embeddings.weight],
+        model.tok_embeddings.weight,
         *[layer.attention.wq.weight for layer in model.layers],
         *[layer.attention.wk.weight for layer in model.layers],
         *[layer.attention.wv.weight for layer in model.layers],
@@ -204,7 +204,6 @@ def version2_export(model, filepath, group_size=64):
         *[layer.feed_forward.w3.weight for layer in model.layers],
     ]
     shared_classifier = torch.equal(model.tok_embeddings.weight, model.output.weight)
-    shared_classifier = 0
     if not shared_classifier:
         weights.append(model.output.weight)
     for w in weights:

--- a/export.py
+++ b/export.py
@@ -194,7 +194,7 @@ def version2_export(model, filepath, group_size=64):
         group_size //= 2
         print(f"BACKOFF: reducing group size to {group_size} to fit hidden_dim")
     weights = [
-        model.tok_embeddings.weight,
+        *[row for row in model.tok_embeddings.weight],
         *[layer.attention.wq.weight for layer in model.layers],
         *[layer.attention.wk.weight for layer in model.layers],
         *[layer.attention.wv.weight for layer in model.layers],
@@ -204,6 +204,7 @@ def version2_export(model, filepath, group_size=64):
         *[layer.feed_forward.w3.weight for layer in model.layers],
     ]
     shared_classifier = torch.equal(model.tok_embeddings.weight, model.output.weight)
+    shared_classifier = 0
     if not shared_classifier:
         weights.append(model.output.weight)
     for w in weights:
@@ -241,21 +242,15 @@ def version2_export(model, filepath, group_size=64):
     # now let's write out all the params that we are quantizing to Q8_0
     # note we skip classifier weights, which are shared with the embedding
     ew = []
-    scales = []
     for i, w in enumerate(weights):
         # quantize this weight
         q, s, err = quantize_q80(w, group_size)
         # save the int8 weights to file
         serialize_int8(out_file, q) # save the tensor in int8
-        scales.append(s)  # we'll do all the scales after all the qs
+        serialize_fp32(out_file, s) # save scale factors
         # logging
         ew.append((err, w.shape))
         print(f"{i+1}/{len(weights)} quantized {tuple(w.shape)} to Q8_0 with max error {err}")
-
-    # save the scaling factors in fp32 here
-    # this is done to keep all the weights contiquous, making pointer arithmetic easier in C
-    for s in scales:
-        serialize_fp32(out_file, s)
 
     # print the highest error across all weights, should be very small, e.g. O(~0.001)
     ew.sort(reverse=True)

--- a/runq.c
+++ b/runq.c
@@ -218,6 +218,16 @@ void build_transformer(Transformer *t, char* checkpoint_path) {
 }
 
 void free_transformer(Transformer* t) {
+    // free QuantizedTensors
+    free(t->weights.token_embedding_table);
+    free(t->weights.wq);
+    free(t->weights.wk);
+    free(t->weights.wv);
+    free(t->weights.wo);
+    free(t->weights.w1);
+    free(t->weights.w2);
+    free(t->weights.w3);
+    free(t->weights.wcls);
     // close the memory mapping
     if (t->data != MAP_FAILED) { munmap(t->data, t->file_size); }
     if (t->fd != -1) { close(t->fd); }

--- a/runq.c
+++ b/runq.c
@@ -38,23 +38,23 @@ typedef struct {
 
 typedef struct {
     // token embedding table
-    QuantizedTensor token_embedding_table; // (vocab_size, dim)
+    QuantizedTensor *token_embedding_table; // (vocab_size, dim)
     // weights for rmsnorms
     float* rms_att_weight; // (layer, dim) rmsnorm weights
     float* rms_ffn_weight; // (layer, dim)
     // weights for matmuls. note dim == n_heads * head_size
-    QuantizedTensor wq; // (layer, dim, n_heads * head_size)
-    QuantizedTensor wk; // (layer, dim, n_kv_heads * head_size)
-    QuantizedTensor wv; // (layer, dim, n_kv_heads * head_size)
-    QuantizedTensor wo; // (layer, n_heads * head_size, dim)
+    QuantizedTensor *wq; // (layer, dim, n_heads * head_size)
+    QuantizedTensor *wk; // (layer, dim, n_kv_heads * head_size)
+    QuantizedTensor *wv; // (layer, dim, n_kv_heads * head_size)
+    QuantizedTensor *wo; // (layer, n_heads * head_size, dim)
     // weights for ffn
-    QuantizedTensor w1; // (layer, hidden_dim, dim)
-    QuantizedTensor w2; // (layer, dim, hidden_dim)
-    QuantizedTensor w3; // (layer, hidden_dim, dim)
+    QuantizedTensor *w1; // (layer, hidden_dim, dim)
+    QuantizedTensor *w2; // (layer, dim, hidden_dim)
+    QuantizedTensor *w3; // (layer, hidden_dim, dim)
     // final rmsnorm
     float* rms_final_weight; // (dim,)
     // (optional) classifier weights for the logits, on the last layer
-    QuantizedTensor wcls;
+    QuantizedTensor *wcls;
 } TransformerWeights;
 
 typedef struct {
@@ -131,6 +131,25 @@ void free_run_state(RunState* s) {
     free(s->value_cache);
 }
 
+/* 
+ * initialize `n` x quantized tensor (with `size_each` elements), starting from memory pointed at *ptr
+ * ptr is advanced accordingly
+ */
+QuantizedTensor *init_quantized_tensors(void **ptr, int n, int size_each) {
+    void *p = *ptr;
+    QuantizedTensor *res = malloc(n * sizeof(QuantizedTensor));
+    for(int i=0; i<n; i++) {
+        /* map quantized int8 values*/
+        res[i].q = (int8_t*)p; 
+        p = (int8_t*)p + size_each;
+        /* map scale factors */
+        res[i].s = (float*)p;
+        p = (float*)p + size_each / GS;
+    }
+    *ptr = p;
+    return res;
+}
+
 void memory_map_weights(TransformerWeights *w, Config* p, void* ptr, uint8_t shared_classifier) {
     int head_size = p->dim / p->n_heads;
     // first are the parameters that are kept in fp32 (the rmsnorm (1D) weights)
@@ -141,54 +160,20 @@ void memory_map_weights(TransformerWeights *w, Config* p, void* ptr, uint8_t sha
     fptr += p->n_layers * p->dim;
     w->rms_final_weight = fptr;
     fptr += p->dim;
+
     // now read all the quantized weights
-    int8_t* qptr = (int8_t*) fptr; // now cast the pointer to int8_t*
-    w->token_embedding_table.q = qptr;
-    qptr += p->vocab_size * p->dim;
-    w->wq.q = qptr;
-    qptr += p->n_layers * p->dim * (p->n_heads * head_size);
-    w->wk.q = qptr;
-    qptr += p->n_layers * p->dim * (p->n_kv_heads * head_size);
-    w->wv.q = qptr;
-    qptr += p->n_layers * p->dim * (p->n_kv_heads * head_size);
-    w->wo.q = qptr;
-    qptr += p->n_layers * (p->n_heads * head_size) * p->dim;
-    w->w1.q = qptr;
-    qptr += p->n_layers * p->dim * p->hidden_dim;
-    w->w2.q = qptr;
-    qptr += p->n_layers * p->hidden_dim * p->dim;
-    w->w3.q = qptr;
-    qptr += p->n_layers * p->dim * p->hidden_dim;
-    if (shared_classifier) {
-        w->wcls.q = w->token_embedding_table.q;
-    } else {
-        w->wcls.q = qptr;
-        qptr += p->dim * p->vocab_size;
-    }
-    // and finally all the associated scaling factors
-    float* sptr = (float*) qptr; // cast pointer back to float*
-    w->token_embedding_table.s = sptr;
-    sptr += p->vocab_size * p->dim / GS;
-    w->wq.s = sptr;
-    sptr += p->n_layers * p->dim * (p->n_heads * head_size) / GS;
-    w->wk.s = sptr;
-    sptr += p->n_layers * p->dim * (p->n_kv_heads * head_size) / GS;
-    w->wv.s = sptr;
-    sptr += p->n_layers * p->dim * (p->n_kv_heads * head_size) / GS;
-    w->wo.s = sptr;
-    sptr += p->n_layers * (p->n_heads * head_size) * p->dim / GS;
-    w->w1.s = sptr;
-    sptr += p->n_layers * p->dim * p->hidden_dim / GS;
-    w->w2.s = sptr;
-    sptr += p->n_layers * p->hidden_dim * p->dim / GS;
-    w->w3.s = sptr;
-    sptr += p->n_layers * p->dim * p->hidden_dim / GS;
-    if (shared_classifier) {
-        w->wcls.s = w->token_embedding_table.s;
-    } else {
-        w->wcls.s = sptr;
-        sptr += p->dim * p->vocab_size / GS;
-    }
+    ptr = (void*)fptr; // now cast the pointer back to void*
+    w->token_embedding_table = init_quantized_tensors(&ptr, p->vocab_size, p->dim);
+    w->wq = init_quantized_tensors(&ptr, p->n_layers, p->dim * (p->n_heads * head_size));
+    w->wk = init_quantized_tensors(&ptr, p->n_layers, p->dim * (p->n_kv_heads * head_size));
+    w->wv = init_quantized_tensors(&ptr, p->n_layers, p->dim * (p->n_kv_heads * head_size));
+    w->wo = init_quantized_tensors(&ptr, p->n_layers, (p->n_heads * head_size) * p->dim);
+
+    w->w1 = init_quantized_tensors(&ptr, p->n_layers, p->dim * p->hidden_dim);
+    w->w2 = init_quantized_tensors(&ptr, p->n_layers, p->hidden_dim * p->dim);
+    w->w3 = init_quantized_tensors(&ptr, p->n_layers, p->dim * p->hidden_dim);
+
+    w->wcls = init_quantized_tensors(&ptr, 1, p->dim * p->vocab_size);
 }
 
 void read_checkpoint(char* checkpoint, Config* config, TransformerWeights* weights,
@@ -278,7 +263,7 @@ void softmax(float* x, int size) {
     }
 }
 
-void matmul(float* xout, int8_t* xq, float* xs, int8_t* wq, float* ws, int n, int d) {
+void matmul(float* xout, QuantizedTensor *x, QuantizedTensor *w, int n, int d) {
     // W (d,n) @ x (n,) -> xout (d,)
     // by far the most amount of time is spent inside this little function
     // inputs to this function are both quantized
@@ -295,9 +280,9 @@ void matmul(float* xout, int8_t* xq, float* xs, int8_t* wq, float* ws, int n, in
         int j;
         for (j = 0; j <= n - GS; j += GS) {
             for (int k = 0; k < GS; k++) {
-                ival += ((int32_t) xq[j + k]) * ((int32_t) wq[in + j + k]);
+                ival += ((int32_t) x->q[j + k]) * ((int32_t) w->q[in + j + k]);
             }
-            val += ((float) ival) * ws[(in + j) / GS] * xs[j / GS];
+            val += ((float) ival) * w->s[(in + j) / GS] * x->s[j / GS];
             ival = 0;
         }
 
@@ -305,13 +290,13 @@ void matmul(float* xout, int8_t* xq, float* xs, int8_t* wq, float* ws, int n, in
     }
 }
 
-void dequantize(int8_t* q, float* s, float* x, int n) {
+void dequantize(QuantizedTensor *qx, float* x, int n) {
     for (int i = 0; i < n; i++) {
-        x[i] = q[i] * s[i / GS];
+        x[i] = qx->q[i] * qx->s[i / GS];
     }
 }
 
-void quantize(float* x, int8_t* q, float* s, int n) {
+void quantize(QuantizedTensor *qx, float* x, int n) {
     int num_groups = n / GS;
     float Q_MAX = 127.0f;
 
@@ -328,13 +313,13 @@ void quantize(float* x, int8_t* q, float* s, int n) {
 
         // calculate and write the scaling factor
         float scale = wmax / Q_MAX;
-        s[group] = scale;
+        qx->s[group] = scale;
 
         // calculate and write the quantized values
         for (int i = 0; i < GS; i++) {
             float quant_value = x[group * GS + i] / scale; // scale
             int8_t quantized = (int8_t) round(quant_value); // round and clamp
-            q[group * GS + i] = quantized;
+            qx->q[group * GS + i] = quantized;
         }
     }
 }
@@ -353,8 +338,7 @@ float* forward(Transformer* transformer, int token, int pos) {
     int head_size = dim / p->n_heads;
 
     // dequantize the token embedding into a float x
-    QuantizedTensor tok = w->token_embedding_table;
-    dequantize(tok.q + token * dim, tok.s + token * dim / GS, x, dim);
+    dequantize(w->token_embedding_table + token, x, dim);
 
     // forward all the layers
     for(int l = 0; l < p->n_layers; l++) {
@@ -363,10 +347,10 @@ float* forward(Transformer* transformer, int token, int pos) {
         rmsnorm(s->xb, x, w->rms_att_weight + l*dim, dim);
 
         // qkv matmuls for this position
-        quantize(s->xb, s->xq.q, s->xq.s, dim);
-        matmul(s->q, s->xq.q, s->xq.s, w->wq.q + l*dim*dim,    w->wq.s + l*dim*dim/GS, dim, dim);
-        matmul(s->k, s->xq.q, s->xq.s, w->wk.q + l*dim*kv_dim, w->wk.s + l*dim*kv_dim/GS, dim, kv_dim);
-        matmul(s->v, s->xq.q, s->xq.s, w->wv.q + l*dim*kv_dim, w->wv.s + l*dim*kv_dim/GS, dim, kv_dim);
+        quantize(&s->xq, s->xb, dim);
+        matmul(s->q, &s->xq, w->wq + l, dim, dim);
+        matmul(s->k, &s->xq, w->wk + l, dim, kv_dim);
+        matmul(s->v, &s->xq, w->wv + l, dim, kv_dim);
 
         // RoPE relative positional encoding: complex-valued rotate q and k in each head
         for (int i = 0; i < dim; i+=2) {
@@ -433,8 +417,8 @@ float* forward(Transformer* transformer, int token, int pos) {
         }
 
         // final matmul to get the output of the attention
-        quantize(s->xb, s->xq.q, s->xq.s, dim);
-        matmul(s->xb2, s->xq.q, s->xq.s, w->wo.q + l*dim*dim, w->wo.s + l*dim*dim/GS, dim, dim);
+        quantize(&s->xq, s->xb, dim);
+        matmul(s->xb2, &s->xq, w->wo + l, dim, dim);
 
         // residual connection back into x
         for (int i = 0; i < dim; i++) {
@@ -446,9 +430,9 @@ float* forward(Transformer* transformer, int token, int pos) {
 
         // Now for FFN in PyTorch we have: self.w2(F.silu(self.w1(x)) * self.w3(x))
         // first calculate self.w1(x) and self.w3(x)
-        quantize(s->xb, s->xq.q, s->xq.s, dim);
-        matmul(s->hb, s->xq.q, s->xq.s, w->w1.q + l*dim*hidden_dim, w->w1.s + l*dim*hidden_dim/GS, dim, hidden_dim);
-        matmul(s->hb2, s->xq.q, s->xq.s, w->w3.q + l*dim*hidden_dim, w->w3.s + l*dim*hidden_dim/GS, dim, hidden_dim);
+        quantize(&s->xq, s->xb, dim);
+        matmul(s->hb, &s->xq, w->w1 + l, dim, hidden_dim);
+        matmul(s->hb2, &s->xq, w->w3 + l, dim, hidden_dim);
 
         // SwiGLU non-linearity
         for (int i = 0; i < hidden_dim; i++) {
@@ -461,8 +445,8 @@ float* forward(Transformer* transformer, int token, int pos) {
         }
 
         // final matmul to get the output of the ffn
-        quantize(s->hb, s->hq.q, s->hq.s, hidden_dim);
-        matmul(s->xb, s->hq.q, s->hq.s, w->w2.q + l*dim*hidden_dim, w->w2.s + l*dim*hidden_dim/GS, hidden_dim, dim);
+        quantize(&s->hq, s->hb, hidden_dim);
+        matmul(s->xb, &s->hq, w->w2 + l, hidden_dim, dim);
 
         // residual connection
         for (int i = 0; i < dim; i++) {
@@ -474,8 +458,8 @@ float* forward(Transformer* transformer, int token, int pos) {
     rmsnorm(x, x, w->rms_final_weight, dim);
 
     // classifier into logits
-    quantize(x, s->xq.q, s->xq.s, dim);
-    matmul(s->logits, s->xq.q, s->xq.s, w->wcls.q, w->wcls.s, dim, p->vocab_size);
+    quantize(&s->xq, x, dim);
+    matmul(s->logits, &s->xq, w->wcls, dim, p->vocab_size);
     return s->logits;
 }
 


### PR DESCRIPTION
This is a refactor PR to be merged to draft PR #364 (branch `feature/int8_try2`):

Summary of changes:
 * `matmul()`, `quantize()` and `dequantize()` all take `QuantizedTensor *` as arguments.
 * Cleaned up `memory_map_weights()`
 * Code does compile and runs as before refactor
