### PR TITLE
Add link to pure Mojo implementation of project

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,8 @@ If your candidate PRs have elements of these it doesn't mean they won't get merg
   - [icpp-llm](https://github.com/icppWorld/icpp-llm): LLMs for the Internet Computer
 - Fortran
   - [llama2.f90](https://github.com/rbitr/llama2.f90): a Fortran port of this project
+- Mojo
+  - [llama2.🔥](https://github.com/tairov/llama2.mojo) by @[tairov](https://github.com/tairov): pure Mojo port of this project
 - [llama2.c - Llama 2 Everywhere](https://github.com/trholding/llama2.c) by @[trholding](https://github.com/trholding): Standalone, Bootable & Portable Binary Llama 2
 - [llama2.c-zh - Bilingual Chinese and English](https://github.com/chenyangMl/llama2.c-zh) by @[chenyangMl](https://github.com/chenyangMl): Expand tokenizer to support training and inference in both Chinese and English
 


### PR DESCRIPTION
I was really excited that Mojo became publicly available and thinking which project can I implement to learn Mojo concepts.

Since I have already ported llama2.c to pure Python, I decided why not try to port llama2.py to Mojo now 😀 

And here is what I got...

I found the SIMD Mojo primitives really interesting feature, since it helped to improve pretty awful performance of Python solution almost 250x times.

Internally I used vectorization helpers for matmul so that now Mojo solution can beat original llama2.c (!) (even in runfast mode) by 15-20%

I think Mojo implementation can unblock further improvements of llama2.c, since it has more advanced tiles & parallelize helpers that can help to see how far can we push hardware level optimizations

