### PR TITLE
Minor fix: Use CLOCK_MONOTONIC instead of CLOCK_REALTIME

### DIFF
--- a/run.c
+++ b/run.c
@@ -724,7 +724,7 @@ int sample(Sampler* sampler, float* logits) {
 long time_in_ms() {
     // return time in milliseconds, for benchmarking the model speed
     struct timespec time;
-    clock_gettime(CLOCK_REALTIME, &time);
+    clock_gettime(CLOCK_MONOTONIC, &time);
     return time.tv_sec * 1000 + time.tv_nsec / 1000000;
 }
 


### PR DESCRIPTION
CLOCK_MONOTONIC is recommended for measuring elapsed time because it guarantees that measurements are not affected by changes to the system clock: https://www.gnu.org/software/libc/manual/html_node/Getting-the-Time.html

