### PR TITLE
Revert "Minor fix: Use CLOCK_MONOTONIC instead of CLOCK_REALTIME"

### DIFF
--- a/run.c
+++ b/run.c
@@ -726,7 +726,7 @@ int sample(Sampler* sampler, float* logits) {
 long time_in_ms() {
     // return time in milliseconds, for benchmarking the model speed
     struct timespec time;
-    clock_gettime(CLOCK_MONOTONIC, &time);
+    clock_gettime(CLOCK_REALTIME, &time);
     return time.tv_sec * 1000 + time.tv_nsec / 1000000;
 }
 


### PR DESCRIPTION
Reverts karpathy/llama2.c#389
Not compatible with windows