### PR TITLE
Support export to HuggingFace

### DIFF
--- a/export.py
+++ b/export.py
@@ -336,7 +336,7 @@ def hf_export(llama_model, filepath, group_size=64, dtype=torch.float32):
     # First make the directory if it doesn't exist
     os.makedirs(filepath, exist_ok=True)
 
-    # Save the state dictionary in .pt format
+    # Save the state dictionary in .bin format, and config as .json
     torch.save(hf_state_dict, os.path.join(filepath, "pytorch_model.bin"))
     config.save_pretrained(filepath)
 

--- a/export.py
+++ b/export.py
@@ -265,7 +265,7 @@ def version2_export(model, filepath, group_size=64):
     out_file.close()
     print(f"wrote {filepath}")
 
-def hf_export(llama_model, filepath, group_size=64, dtype=torch.float16):
+def hf_export(llama_model, filepath, group_size=64, dtype=torch.float32):
     """ Generate the pytorch_model.bin state_dict and config.json for HuggingFace """
 
     try:

--- a/export.py
+++ b/export.py
@@ -468,6 +468,7 @@ def load_hf_model(model_path):
     model.eval()
     return model
 
+
 # -----------------------------------------------------------------------------
 # API entrypoint
 

--- a/export.py
+++ b/export.py
@@ -268,6 +268,13 @@ def version2_export(model, filepath, group_size=64):
 def hf_export(llama_model, filepath, group_size=64):
     """ Generate the pytorch_model.bin state_dict and config.json for HuggingFace """
 
+    try:
+        from transformers.models.llama.configuration_llama import LlamaConfig
+    except ImportError:
+        print("Error: transformers package is required to load huggingface models")
+        print("Please run `pip install transformers` to install it")
+        return None
+
     # Generate LlamaModel state_dict
     def permute_original(w, n_heads=llama_model.params.n_heads, dim1=llama_model.params.dim, dim2=llama_model.params.dim):
         return w.view(dim1, dim2).reshape(n_heads, dim1 // n_heads // 2, 2, dim2).transpose(1, 2).reshape(dim1, dim2)
@@ -294,7 +301,6 @@ def hf_export(llama_model, filepath, group_size=64):
 
 
     # Generate LlamaConfig (seen in transformers.models.llama.configuration_llama)
-    from transformers.models.llama.configuration_llama import LlamaConfig
 
     # Extract necessary attributes from llama.c model
     vocab_size = llama_model.params.vocab_size

--- a/export.py
+++ b/export.py
@@ -297,7 +297,9 @@ def hf_export(llama_model, filepath, group_size=64, dtype=torch.float16):
         hf_state_dict[f'model.layers.{i}.mlp.down_proj.weight'] = llama_model.layers[layer_id].feed_forward.w2.weight.clone().to(dtype)
         hf_state_dict[f'model.layers.{i}.mlp.up_proj.weight'] = llama_model.layers[layer_id].feed_forward.w3.weight.clone().to(dtype)
 
-    hf_state_dict['lm_head.weight'] = llama_model.output.weight.clone().to(dtype)
+    # llama2.c uses tied weights, so we reference the embed_tokens.weights instead
+    #hf_state_dict['lm_head.weight'] = llama_model.output.weight.clone().to(dtype)
+    hf_state_dict['lm_head.weight'] = hf_state_dict['model.embed_tokens.weight']
 
 
     # Generate LlamaConfig (seen in transformers.models.llama.configuration_llama)

--- a/export.py
+++ b/export.py
@@ -480,7 +480,8 @@ def load_hf_model(model_path):
 # -----------------------------------------------------------------------------
 # API entrypoint
 
-def model_export(model, filepath, version):
+def model_export(model, filepath, version, dtype=torch.float32):
+    # TODO: add dtype export support for other versions
     if version == 0:
         legacy_export(model, filepath)
     elif version == 1:
@@ -488,7 +489,7 @@ def model_export(model, filepath, version):
     elif version == 2:
         version2_export(model, filepath)
     elif version == -1:
-        hf_export(model, filepath)
+        hf_export(model, filepath, dtype)
     else:
         raise ValueError(f"unknown version {version}")
 
@@ -528,11 +529,13 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("filepath", type=str, help="the output filepath")
     parser.add_argument("--version", default=0, type=int, help="the version to export with")
+    parser.add_argument("--dtype", type=str, help="dtype of the model (fp16, fp32)", default="fp32")
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument("--checkpoint", type=str, help="model checkpoint, .pt file")
     group.add_argument("--meta-llama", type=str, help="meta llama model path")
     group.add_argument("--hf", type=str, help="huggingface model path")
     args = parser.parse_args()
+    dtype = {"fp16": torch.float16, "fp32": torch.float32}[args.dtype]
 
     if args.checkpoint:
         model = load_checkpoint(args.checkpoint)
@@ -545,4 +548,4 @@ if __name__ == "__main__":
         parser.error("Can't load input model!")
 
     # export
-    model_export(model, args.filepath, args.version)
+    model_export(model, args.filepath, args.version, args.dtype)

--- a/export.py
+++ b/export.py
@@ -265,7 +265,7 @@ def version2_export(model, filepath, group_size=64):
     out_file.close()
     print(f"wrote {filepath}")
 
-def hf_export(llama_model, filepath, group_size=64):
+def hf_export(llama_model, filepath, group_size=64, dtype=torch.float16):
     """ Generate the pytorch_model.bin state_dict and config.json for HuggingFace """
 
     try:
@@ -282,22 +282,22 @@ def hf_export(llama_model, filepath, group_size=64):
     hf_state_dict = {}
 
     # Transfer weights from llama model to the HF state dictionary format
-    hf_state_dict['model.embed_tokens.weight'] = llama_model.tok_embeddings.weight.clone()
-    hf_state_dict['model.norm.weight'] = llama_model.norm.weight.clone()
+    hf_state_dict['model.embed_tokens.weight'] = llama_model.tok_embeddings.weight.clone().to(dtype)
+    hf_state_dict['model.norm.weight'] = llama_model.norm.weight.clone().to(dtype)
 
     for i, layer in enumerate(llama_model.layers):
         layer_id = layer.layer_id  # Assuming llama.c layers have layer_id
-        hf_state_dict[f'model.layers.{i}.input_layernorm.weight'] = llama_model.layers[layer_id].attention_norm.weight.clone()
-        hf_state_dict[f'model.layers.{i}.self_attn.q_proj.weight'] = permute_original(llama_model.layers[layer_id].attention.wq.weight.clone())
-        hf_state_dict[f'model.layers.{i}.self_attn.k_proj.weight'] = permute_original(llama_model.layers[layer_id].attention.wk.weight.clone())
-        hf_state_dict[f'model.layers.{i}.self_attn.v_proj.weight'] = llama_model.layers[layer_id].attention.wv.weight.clone()
-        hf_state_dict[f'model.layers.{i}.self_attn.o_proj.weight'] = llama_model.layers[layer_id].attention.wo.weight.clone()
-        hf_state_dict[f'model.layers.{i}.post_attention_layernorm.weight'] = llama_model.layers[layer_id].ffn_norm.weight.clone()
-        hf_state_dict[f'model.layers.{i}.mlp.gate_proj.weight'] = llama_model.layers[layer_id].feed_forward.w1.weight.clone()
-        hf_state_dict[f'model.layers.{i}.mlp.down_proj.weight'] = llama_model.layers[layer_id].feed_forward.w2.weight.clone()
-        hf_state_dict[f'model.layers.{i}.mlp.up_proj.weight'] = llama_model.layers[layer_id].feed_forward.w3.weight.clone()
+        hf_state_dict[f'model.layers.{i}.input_layernorm.weight'] = llama_model.layers[layer_id].attention_norm.weight.clone().to(dtype)
+        hf_state_dict[f'model.layers.{i}.self_attn.q_proj.weight'] = permute_original(llama_model.layers[layer_id].attention.wq.weight.clone()).to(dtype)
+        hf_state_dict[f'model.layers.{i}.self_attn.k_proj.weight'] = permute_original(llama_model.layers[layer_id].attention.wk.weight.clone()).to(dtype)
+        hf_state_dict[f'model.layers.{i}.self_attn.v_proj.weight'] = llama_model.layers[layer_id].attention.wv.weight.clone().to(dtype)
+        hf_state_dict[f'model.layers.{i}.self_attn.o_proj.weight'] = llama_model.layers[layer_id].attention.wo.weight.clone().to(dtype)
+        hf_state_dict[f'model.layers.{i}.post_attention_layernorm.weight'] = llama_model.layers[layer_id].ffn_norm.weight.clone().to(dtype)
+        hf_state_dict[f'model.layers.{i}.mlp.gate_proj.weight'] = llama_model.layers[layer_id].feed_forward.w1.weight.clone().to(dtype)
+        hf_state_dict[f'model.layers.{i}.mlp.down_proj.weight'] = llama_model.layers[layer_id].feed_forward.w2.weight.clone().to(dtype)
+        hf_state_dict[f'model.layers.{i}.mlp.up_proj.weight'] = llama_model.layers[layer_id].feed_forward.w3.weight.clone().to(dtype)
 
-    hf_state_dict['lm_head.weight'] = llama_model.output.weight.clone()
+    hf_state_dict['lm_head.weight'] = llama_model.output.weight.clone().to(dtype)
 
 
     # Generate LlamaConfig (seen in transformers.models.llama.configuration_llama)
@@ -335,7 +335,7 @@ def hf_export(llama_model, filepath, group_size=64):
     os.makedirs(filepath, exist_ok=True)
 
     # Save the state dictionary in .pt format
-    torch.save(hf_state_dict, os.path.join(filepath, "pytorch_model.pt"))
+    torch.save(hf_state_dict, os.path.join(filepath, "pytorch_model.bin"))
     config.save_pretrained(filepath)
 
 


### PR DESCRIPTION
Added option to export to huggingface format. This involves creating a folder with `config.json` and `pytorch_model.bin`.

Possible things that could be done: 
- Add export for tokenizer to huggingface format as well.
- Manually add the RoPE embeddings.
- Change versioning to be string (currently export to hf is when `version == -1`).
- Ensure that default values in LlamaConfig match up for the config files.

Loads without error into `LlamaForCausalLM.from_pretrained()` but have not tested with a tokenizer.