### PR TITLE
Add a Java port information in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,7 @@ If your candidate PRs have elements of these it doesn't mean they won't get merg
   - [llama2.scala](https://github.com/jrudolph/llama2.scala) by @[jrudolph](https://github.com/jrudolph): a Scala port of this project
 - Java
   - [llama2.java](https://github.com/mukel/llama2.java) by @[mukel](https://github.com/mukel): a Java port of this project
+  - [llama2.java](https://github.com/neoremind/llama2.java) by @[neoremind](https://github.com/neoremind): a Java port of this project
 - Kotlin
   - [llama2.kt](https://github.com/madroidmaq/llama2.kt) by @[madroidmaq](https://github.com/madroidmaq): a Kotlin port of this project
 - Python


### PR DESCRIPTION
This is a port of llama2.c in Java. The implementation is able to inference both the stories series baby llama2 models and Meta’s llama2 7B model. 

The piece of work is done with educational purpose, and it enriches llama2.c forks.

In terms of performance, llama2.java offers the similar level of token/s compared with pure C version. 

I will keep updating and enhancing the forked version with the base C implementation.