### PR TITLE
Update run.ipynb to use export.py and --meta-llama parameter

### DIFF
--- a/run.ipynb
+++ b/run.ipynb
@@ -105,7 +105,7 @@
         "token = \"replace your huggingface access token\" #@param {type:\"string\"}\n",
         "path = snapshot_download(repo_id=\"meta-llama/Llama-2-7b\",cache_dir=\"Llama-2-7b\", use_auth_token=token)\n",
         "\n",
-        "!python export_meta_llama_bin.py $path llama2_7b.bin\n",
+        "!python export.py llama2_7b.bin --meta-llama $path\n",
         "\n",
         "print(\"./run llama2_7b.bin\\n\")\n",
         "!./run llama2_7b.bin"


### PR DESCRIPTION
Already _export_meta_llama_bin.py_ was replaced with _export.py_ and _README.md_ file was updated accordingly.  But this notebook wasn't updated yet.

The Python command is updated to use the _export.py_ file.