### PR TITLE
Proof of Concept - Add Support for build.zig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+zig-cache/
+zig-out/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,22 @@
 ## llama2.c
 
+## Zig Build Support
+
+This is fork of the original project with support for build.zig
+
+Here are the instructions to use it
+
+```
+cd llama2.c
+zig build
+wget https://huggingface.co/karpathy/tinyllamas/resolve/main/stories15M.bin
+mv ./zig-out/bin/run
+./run stories15M.bin
+```
+Tested with zig 0.11.0
+
+## Introduction
+
 <p align="center">
   <img src="assets/llama_cute.jpg" width="300" height="300" alt="Cute Llama">
 </p>

--- a/build.zig
+++ b/build.zig
@@ -1,0 +1,38 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    // Add run executable
+    const run_exe = b.addExecutable(.{
+        .name = "run", 
+        .root_source_file = .{ .path = "run.c" },
+        .target = target,
+        // .link_libc = true,
+        .optimize = optimize,
+    });
+    // run_exe.linkSystemLibrary("m");
+
+    // Add runq executable 
+    const runq_exe = b.addExecutable(.{
+        .name = "runq",
+        .root_source_file = .{ .path = "runq.c" },
+        .target = target,
+        // .link_libc = true,
+        .optimize = optimize,
+    });
+    // runq_exe.linkSystemLibrary("m");
+
+    // Add test executable
+    const test_exe = b.addExecutable(.{
+        .name = "test",
+        .root_source_file = .{ .path = "test.c" }, 
+        .target = target,
+        .optimize = optimize,
+    });
+
+    b.installArtifact(run_exe);
+    b.installArtifact(runq_exe);
+    b.installArtifact(test_exe);
+}


### PR DESCRIPTION
Here is initial support to use zig as build tool chain as opposed to make files, this bring the ability to do cross compilation on any supported zig build target