### PR TITLE
README: add Kotlin Multiplatform port

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,7 @@ If your candidate PRs have elements of these it doesn't mean they won't get merg
   - [llama2.java](https://github.com/mukel/llama2.java) by @[mukel](https://github.com/mukel): a Java port of this project
 - Kotlin
   - [llama2.kt](https://github.com/madroidmaq/llama2.kt) by @[madroidmaq](https://github.com/madroidmaq): a Kotlin port of this project
+  - [llama2-kmp](https://github.com/stepango/llama2-kmp) by @[stepango](https://github.com/stepango): a Kotlin multiplatform(KMP) port of this project 
 - Python
   - [llama2.py](https://github.com/tairov/llama2.py) by @[tairov](https://github.com/tairov): a simple one file pure Python port of this project with zero dependencies
 - C#


### PR DESCRIPTION
Kotlin Multiplatform(KMP) port of llama2.c 

Supports Linux/MacOS/Windows/Js/JVM platforms