### PR TITLE
dd link to fork llama2Rnn.c

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,7 @@ If your candidate PRs have elements of these it doesn't mean they won't get merg
   - [llama2.ha](https://sr.ht/~dvshkn/llama2.ha) by @[dvshkn](https://git.sr.ht/~dvshkn): a Hare port of this project
 - [llama2.c - Llama 2 Everywhere](https://github.com/trholding/llama2.c) by @[trholding](https://github.com/trholding): Standalone, Bootable & Portable Binary Llama 2
 - [llama2.c-zh - Bilingual Chinese and English](https://github.com/chenyangMl/llama2.c-zh) by @[chenyangMl](https://github.com/chenyangMl): Expand tokenizer to support training and inference in both Chinese and English
+- [llama2Rnn.c](https://github.com/siyuanseever/llama2Rnn.c) by @[siyuanseever](https://github.com/siyuanseever): a Recurrent Neural Network (RNN) model designed to run indefinitely (lifelong) using Llama2
 - Haskell
   - [llama2.hs](https://github.com/chris-ch/llama2.hs) by @[chris-ch](https://github.com/chris-ch): an Haskell port of this project
 


### PR DESCRIPTION
This commit adds a direct link in the README file to the forked repository which contains an version of the llama2Rnn.c module. 
This makes it easier for users to find and utilize the improvements made in the fork.