### PR TITLE
Use `int` instead of `float` to calculate `weights_ptr`

### DIFF
--- a/run.c
+++ b/run.c
@@ -157,7 +157,7 @@ void read_checkpoint(char* checkpoint, Config* config, TransformerWeights* weigh
     if (*fd == -1) { fprintf(stderr, "open failed!\n"); exit(EXIT_FAILURE); }
     *data = mmap(NULL, *file_size, PROT_READ, MAP_PRIVATE, *fd, 0);
     if (*data == MAP_FAILED) { fprintf(stderr, "mmap failed!\n"); exit(EXIT_FAILURE); }
-    float* weights_ptr = *data + sizeof(Config)/sizeof(float);
+    float* weights_ptr = *data + sizeof(Config)/sizeof(int);
     memory_map_weights(weights, config, weights_ptr, shared_weights);
 }
 


### PR DESCRIPTION
The `Config` structure consists of 7 fields of `int` type, so we should use `int` instead of `float` when calculating `weights_ptr`.