### PR TITLE
Windows _fseeki64 _ftelli64 bug fix to load LLaMA2 7B >4GB weight

### DIFF
--- a/run.c
+++ b/run.c
@@ -149,8 +149,13 @@ void read_checkpoint(char* checkpoint, Config* config, TransformerWeights* weigh
     int shared_weights = config->vocab_size > 0 ? 1 : 0;
     config->vocab_size = abs(config->vocab_size);
     // figure out the file size
+#if defined _WIN32
+    _fseeki64(file, 0, SEEK_END); // move file pointer to end of file
+    *file_size = _ftelli64(file); // get the file size, in bytes
+#else
     fseek(file, 0, SEEK_END); // move file pointer to end of file
     *file_size = ftell(file); // get the file size, in bytes
+#endif
     fclose(file);
     // memory map the Transformer weights into the data pointer
     *fd = open(checkpoint, O_RDONLY); // open in read only mode


### PR DESCRIPTION
Currently, large file support in Windows is borked for master branch. This is the minimum change to get LLaMA 7B (26GB) to run in Windows. For files over 4GB, we need to use a different set of API to replace POSIX fseek and ftell.

$ gcc -v
Target: x86_64-w64-mingw32
Thread model: posix
Supported LTO compression algorithms: zlib zstd
gcc version 13.2.0 (Rev6, Built by MSYS2 project)