### PR TITLE
Fix potential pointer math truncation and improve readability

### DIFF
--- a/runq.c
+++ b/runq.c
@@ -224,9 +224,9 @@ void read_checkpoint(char* checkpoint, Config* config, TransformerWeights* weigh
     if (*fd == -1) { fprintf(stderr, "Couldn't open file %s\n", checkpoint); exit(EXIT_FAILURE); }
     *file_size = lseek(*fd, 0, SEEK_END); // get the file size, in bytes
     // memory map the Config and Transformer weights into the data pointer
-    *data = mmap(NULL, *file_size, PROT_READ, MAP_PRIVATE, *fd, 0);
+    uint8_t* cur = *data = mmap(NULL, *file_size, PROT_READ, MAP_PRIVATE, *fd, 0);
     if (*data == MAP_FAILED) { fprintf(stderr, "mmap failed!\n"); exit(EXIT_FAILURE); }
-    uint8_t* cur = *data;
+    // read in magic number (uint32), has to be 0x616b3432, i.e. "ak42" in ASCII
     uint32_t magic_number = *(uint32_t*)cur;
     cur += sizeof(uint32_t);
     if (magic_number != 0x616b3432) { fprintf(stderr, "Bad magic number\n"); exit(EXIT_FAILURE); }


### PR DESCRIPTION
Fix potential pointer math truncation bug. Improve readability of datatypes when binary length or handling is at play.

- Fix potential pointer error due to integer truncation in read_checkpoint. Although unlikely due to compiler padding, `*data + sizeof(Config)/sizeof(float);` could can been fractional and thus truncated, leading to an incorrect pointer. Admittedly rare given the pointer padding, but given how people depend on llama2.c as a canonical learning resource, it should be fixed.
- Simplify reading of weights by opening the file only once. Less LOC, less opens by using just one fd now.
- Simplify code related to "data = start of file + sizeof(config)" in that same function
- Add packing pragmas to ensure that the compiler understands we're reading a binary file in mmap'd structs to avoid implicit padding anywhere in the structs. Although offsets of 4x bytes often works out of the box, I'd hate for people to copy/paste this code and in some case get unexpected results/corrupt pointers.
- Simplify/clarify datatypes for a few places where we're dealing with binary data and binary math such as Config and rng_seed: use uint64_t and [u]int32_t to make it absolutely clear what the binary format is and what length's we're dealing with rather than depending on compiler convention of `int` and `unsigned long long`
- improvement: parse CLI flag seed as a uint64_t rather than `int`, unlocking the full range of possible seeds rather than just those up to `2^31-1`