### PR TITLE
add GPT.c port to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,7 @@ If your candidate PRs have elements of these it doesn't mean they won't get merg
   - [llama2.c-android-wrapper](https://github.com/celikin/llama2.c-android-wrapper): by @[celikin](https://github.com/celikin): added JNI wrapper, PoC
 - C
   - [llama3.c](https://github.com/jameswdelancey/llama3.c): by @[jameswdelancey](https://github.com/jameswdelancey): a LLaMA 3 8B Base and Instruct port of this project
+  - [GPT.c](https://github.com/MYusufY/gpt.c): by @[MYusufY](https://github.com/MYusufY): a GPT port of this project
 - C++
   - [llama2.cpp](https://github.com/leloykun/llama2.cpp) by @[leloykun](https://github.com/leloykun): a C++ port of this project
   - [llama2.cpp](https://github.com/coldlarry/llama2.cpp) by @[coldlarry](https://github.com/coldlarry): a C++ port of this project


### PR DESCRIPTION
Hello!

First, I just want to say that this project is really inspiring. As a 13 year-old developer, I’ve learned a lot from reading the code.

As a weekend project, I created a custom GPT-like version of Llama2.c.  
Initially, my goal was to build a pure C inference engine for nanoGPT models (similar to Llama2.c), but the project evolved quickly and I ended up making a custom GPT-style implementation instead. The nanoGPT support is still experimental, but I plan to add a more stable export option for it soon.

My main focus now is implementing GPT.c on ESP32, like existing Llama2.c ports such as [this one](https://github.com/DaveBben/esp32-llm).

Would it be okay to add this project to the list of forks in the README? I think it could be useful for others interested in GPT-like versions.

Thanks again for your great work and contributions to open-source AI!