### PR TITLE
Adding my contribution llama2 on PSP

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,7 +400,8 @@ If your candidate PRs have elements of these it doesn't mean they won't get merg
 - [llama2.c-zh - Bilingual Chinese and English](https://github.com/chenyangMl/llama2.c-zh) by @[chenyangMl](https://github.com/chenyangMl): Expand tokenizer to support training and inference in both Chinese and English
 - Haskell
   - [llama2.hs](https://github.com/chris-ch/llama2.hs) by @[chris-ch](https://github.com/chris-ch): an Haskell port of this project
-
+- PSP
+  - [llama2-psp]([https://github.com/chris-ch/llama2.hs](https://github.com/caiomadeira/llama2-psp)) by @[caiomadeira]([https://github.com/chris-ch](https://github.com/caiomadeira)): llama2.c on Playstation Portable
 ## unsorted todos
 
 - add support in run.c of reading version 1+ files from export, later deprecate "version 0"

--- a/README.md
+++ b/README.md
@@ -401,7 +401,7 @@ If your candidate PRs have elements of these it doesn't mean they won't get merg
 - Haskell
   - [llama2.hs](https://github.com/chris-ch/llama2.hs) by @[chris-ch](https://github.com/chris-ch): an Haskell port of this project
 - PSP
-  - [llama2-psp]([https://github.com/chris-ch/llama2.hs](https://github.com/caiomadeira/llama2-psp)) by @[caiomadeira]([https://github.com/chris-ch](https://github.com/caiomadeira)): llama2.c on Playstation Portable
+  - [llama2-psp](https://github.com/caiomadeira/llama2-psp) by @[caiomadeira](https://github.com/caiomadeira): llama2.c on Playstation Portable
 ## unsorted todos
 
 - add support in run.c of reading version 1+ files from export, later deprecate "version 0"


### PR DESCRIPTION
Recently i port llama2.c to sony playstation portable (PSP).

[hackday post](https://hackaday.com/2025/08/17/llama-habitat-continues-to-expand-now-includes-the-psp/?fbclid=IwY2xjawMv-DdleHRuA2FlbQIxMQBicmlkETFYYks0bGR2M3hPYlZKaUtXAR7yzkNwDF9P09Y5WUejtMTI3PlS64PRLj1O7E81JXDOPFKd4jenBEkgngUfPA_aem_BlZup1O-GdL-HP1RsiuUGA)

[yann lecun post](https://www.facebook.com/yann.lecun/posts/llama-2-has-been-ported-to-the-psp-in-addition-to-the-raspberry-pi-486-pc-commod/10161114909482143/)